### PR TITLE
Feat/team

### DIFF
--- a/backend/src/main/java/com/api/backend/category/data/entity/ScheduleCategory.java
+++ b/backend/src/main/java/com/api/backend/category/data/entity/ScheduleCategory.java
@@ -45,6 +45,7 @@ public class ScheduleCategory extends BaseEntity {
   private Team team;
 
   @OneToMany(mappedBy = "scheduleCategory")
+  @Builder.Default
   private List<Schedule> schedule = new ArrayList<>();
 
   public void editScheduleCategory(ScheduleCategoryEditRequest request) {

--- a/backend/src/main/java/com/api/backend/documents/data/entity/Documents.java
+++ b/backend/src/main/java/com/api/backend/documents/data/entity/Documents.java
@@ -40,6 +40,7 @@ public class Documents extends BaseEntity {
   private Team team;
 
   @OneToMany(mappedBy = "documents")
+  @Builder.Default
   private List<Comment> comments = new ArrayList<>();
 
 }

--- a/backend/src/main/java/com/api/backend/global/exception/type/ErrorCode.java
+++ b/backend/src/main/java/com/api/backend/global/exception/type/ErrorCode.java
@@ -21,10 +21,12 @@ public enum ErrorCode {
   // teamParticipant
   TEAM_PARTICIPANT_DELETE_NOT_VALID_EXCEPTION(500, "팀장 권한을 위임해야지 팀 탈퇴가 가능합니다."),
   TEAM_PARTICIPANT_NOT_VALID_READER_EXCEPTION(500, "팀장 권한이 있어야 합니다."),
+  TEAM_PARTICIPANT_EQUALS_EXCEPTION(500, "동일한 회원을 삭제할려고 하고 있습니다."),
   TEAM_PARTICIPANT_NOT_VALID_MATE_EXCEPTION(500, "팀원 권한이 있어야 합니다."),
   TEAM_PARTICIPANTS_NOT_FOUND_EXCEPTION(500, "존재하지 않는 팀원입니다."),
   TEAM_PARTICIPANTS_NOT_VALID_EXCEPTION(500, "해당 팀의 팀원이 아닙니다."),
   TEAM_PARTICIPANTS_EXIST_EXCEPTION(500, "이미 해당 팀의 일원입니다."),
+  TEAM_PARTICIPANTS_EQUALS_EXCEPTION(500, "나 자신을 가리키고 있습니다.."),
   TEAM_PARTICIPANTS_NOT_LEADER_EXCEPTION(500, "팀 해체는 리더만 가능합니다."),
 
   MEMBER_NOT_FOUND_EXCEPTION(500, "존재하지 않는 회원입니다."),

--- a/backend/src/main/java/com/api/backend/global/exception/type/ErrorCode.java
+++ b/backend/src/main/java/com/api/backend/global/exception/type/ErrorCode.java
@@ -10,11 +10,23 @@ public enum ErrorCode {
   ENUM_NOT_FOUND_EXCEPTION(500, "비어있는 ENUM입니다."),
   SCHEDULE_CATEGORY_NOT_FOUND_EXCEPTION(500, "존재하지 않는 일정 카테고리 입니다."),
   SCHEDULE_CATEGORY_ALREADY_EXIST_EXCEPTION(500, "이미 존재하는 일정 카테고리 입니다."),
+  // team
   TEAM_NOT_FOUND_EXCEPTION(500, "존재하지 않는 팀입니다."),
   TEAM_CODE_NOT_VALID_EXCEPTION(500, "팀 코드가 일치하지 않습니다."),
+  TEAM_IS_DELETE_TRUE_EXCEPTION(500, "해당 팀 이미 해체된 팀입니다."),
+  TEAM_NOT_DELETEING_EXCEPTION(500, "해당 팀은 해체 중이 아닙니다."),
+  TEAM_RESTORE_EXPIRED_EXCEPTION(500, "해당 팀은 해체 기한이 지났습니다."),
+  TEAM_IS_DELETEING_EXCEPTION(500, "해당 팀 이미 해체 중에 있습니다."),
+
+  // teamParticipant
+  TEAM_PARTICIPANT_DELETE_NOT_VALID_EXCEPTION(500, "팀장 권한을 위임해야지 팀 탈퇴가 가능합니다."),
+  TEAM_PARTICIPANT_NOT_VALID_READER_EXCEPTION(500, "팀장 권한이 있어야 합니다."),
+  TEAM_PARTICIPANT_NOT_VALID_MATE_EXCEPTION(500, "팀원 권한이 있어야 합니다."),
   TEAM_PARTICIPANTS_NOT_FOUND_EXCEPTION(500, "존재하지 않는 팀원입니다."),
   TEAM_PARTICIPANTS_NOT_VALID_EXCEPTION(500, "해당 팀의 팀원이 아닙니다."),
   TEAM_PARTICIPANTS_EXIST_EXCEPTION(500, "이미 해당 팀의 일원입니다."),
+  TEAM_PARTICIPANTS_NOT_LEADER_EXCEPTION(500, "팀 해체는 리더만 가능합니다."),
+
   MEMBER_NOT_FOUND_EXCEPTION(500, "존재하지 않는 회원입니다."),
   TOKEN_EXPIRED_EXCEPTION(500, "토큰이 만료 되었습니다."),
   EMAIL_NOT_FOUND_EXCEPTION(400, "해당 이메일로 가입한 사용자가 존재하지 않습니다."),

--- a/backend/src/main/java/com/api/backend/member/data/entity/Member.java
+++ b/backend/src/main/java/com/api/backend/member/data/entity/Member.java
@@ -48,11 +48,14 @@ public class Member extends BaseEntity {
   private String memberProfileUrl;
 
   @OneToMany(mappedBy = "member")
+  @Builder.Default
   private List<Comment> comments = new ArrayList<>();
 
   @OneToMany(mappedBy = "member")
+  @Builder.Default
   private List<Notification> notifications = new ArrayList<>();
 
   @OneToMany(mappedBy = "member")
+  @Builder.Default
   private List<TeamParticipants> teamParticipants = new ArrayList<>();
 }

--- a/backend/src/main/java/com/api/backend/team/controller/TeamController.java
+++ b/backend/src/main/java/com/api/backend/team/controller/TeamController.java
@@ -6,6 +6,7 @@ import com.api.backend.team.data.dto.TeamCreateRequest;
 import com.api.backend.team.data.dto.TeamCreateResponse;
 import com.api.backend.team.data.dto.TeamDisbandRequest;
 import com.api.backend.team.data.dto.TeamDisbandResponse;
+import com.api.backend.team.data.dto.TeamDtoResponse;
 import com.api.backend.team.data.dto.TeamKickOutRequest;
 import com.api.backend.team.data.dto.TeamKickOutResponse;
 import com.api.backend.team.data.dto.TeamRestoreResponse;
@@ -16,6 +17,8 @@ import java.security.Principal;
 import java.time.LocalDate;
 import javax.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -109,4 +112,15 @@ public class TeamController {
     );
   }
 
+  @GetMapping("/list")
+  public ResponseEntity<Page<TeamDtoResponse>> getTeamsRequest(
+      Principal principal,
+      Pageable pageable
+  ){
+    return ResponseEntity.ok(
+        TeamDtoResponse.fromDtos(
+            teamService.getTeams(principal.getName(), pageable)
+        )
+    );
+  }
 }

--- a/backend/src/main/java/com/api/backend/team/controller/TeamController.java
+++ b/backend/src/main/java/com/api/backend/team/controller/TeamController.java
@@ -4,6 +4,8 @@ import static com.api.backend.team.data.ResponseMessage.UPDATE_TEAM_PARTICIPANTS
 
 import com.api.backend.team.data.dto.TeamCreateRequest;
 import com.api.backend.team.data.dto.TeamCreateResponse;
+import com.api.backend.team.data.dto.TeamDisbandRequest;
+import com.api.backend.team.data.dto.TeamDisbandResponse;
 import com.api.backend.team.data.dto.TeamKickOutRequest;
 import com.api.backend.team.data.dto.TeamKickOutResponse;
 import com.api.backend.team.data.dto.UpdateTeamParticipantsResponse;
@@ -16,6 +18,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -32,10 +35,10 @@ public class TeamController {
   public ResponseEntity<TeamCreateResponse> createTeamRequest(
       @RequestBody @Valid
       TeamCreateRequest teamRequest,
-      @RequestParam(value = "userId") String userId
+      Principal principal
   ) {
     return ResponseEntity.ok(
-            teamService.createTeam(teamRequest,userId)
+            teamService.createTeam(teamRequest,principal.getName())
     );
   }
 
@@ -73,6 +76,18 @@ public class TeamController {
   ) {
     return ResponseEntity.ok(
         teamService.kickOutTeamParticipants(teamKickOutRequest, principal.getName())
+    );
+  }
+
+  @PutMapping("/disband")
+  public ResponseEntity<TeamDisbandResponse> disbandTeamRequest(
+      @RequestBody @Valid TeamDisbandRequest request,
+      Principal principal
+  ) {
+    return ResponseEntity.ok(
+        TeamDisbandResponse.from(
+            teamService.disbandTeam(principal.getName(), request)
+        )
     );
   }
 

--- a/backend/src/main/java/com/api/backend/team/controller/TeamController.java
+++ b/backend/src/main/java/com/api/backend/team/controller/TeamController.java
@@ -9,6 +9,7 @@ import com.api.backend.team.data.dto.TeamKickOutResponse;
 import com.api.backend.team.data.dto.UpdateTeamParticipantsResponse;
 import com.api.backend.team.data.entity.Team;
 import com.api.backend.team.service.TeamService;
+import java.security.Principal;
 import javax.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -40,21 +41,21 @@ public class TeamController {
 
   @GetMapping("/{teamId}/code")
   public ResponseEntity<String> getTeamUrlRequest(
-      @PathVariable("teamId") Long teamId
-      // todo Princial를 통한 유저 객체 가져오기
+      @PathVariable("teamId") Long teamId,
+      Principal principal
   ) {
     return ResponseEntity.ok(
-        teamService.getTeamUrl(teamId,null)
+        teamService.getTeamUrl(teamId, principal.getName())
     );
   }
 
   @PostMapping("/{teamId}/{code}")
   public ResponseEntity<UpdateTeamParticipantsResponse> updateTeamParticipantRequest(
       @PathVariable("teamId") Long teamId,
-      @PathVariable("code") String code
-      // todo Princial를 통한 유저 객체 가져오기
+      @PathVariable("code") String code,
+      Principal principal
   ) {
-    Team team = teamService.updateTeamParticipants(teamId, code, null);
+    Team team = teamService.updateTeamParticipants(teamId, code, principal.getName());
     return ResponseEntity.ok(
         UpdateTeamParticipantsResponse
             .builder().teamName(team.getName())
@@ -67,10 +68,11 @@ public class TeamController {
   @PostMapping("/kick-out")
   public ResponseEntity<TeamKickOutResponse> kickOutTeamParticipantsRequest(
       @RequestBody @Valid
-      TeamKickOutRequest teamKickOutRequest
+      TeamKickOutRequest teamKickOutRequest,
+      Principal principal
   ) {
     return ResponseEntity.ok(
-        teamService.kickOutTeamParticipants(teamKickOutRequest)
+        teamService.kickOutTeamParticipants(teamKickOutRequest, principal.getName())
     );
   }
 

--- a/backend/src/main/java/com/api/backend/team/controller/TeamController.java
+++ b/backend/src/main/java/com/api/backend/team/controller/TeamController.java
@@ -8,14 +8,18 @@ import com.api.backend.team.data.dto.TeamDisbandRequest;
 import com.api.backend.team.data.dto.TeamDisbandResponse;
 import com.api.backend.team.data.dto.TeamKickOutRequest;
 import com.api.backend.team.data.dto.TeamKickOutResponse;
+import com.api.backend.team.data.dto.TeamRestoreResponse;
 import com.api.backend.team.data.dto.UpdateTeamParticipantsResponse;
 import com.api.backend.team.data.entity.Team;
 import com.api.backend.team.service.TeamService;
 import java.security.Principal;
+import java.time.LocalDate;
 import javax.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
@@ -87,6 +91,20 @@ public class TeamController {
     return ResponseEntity.ok(
         TeamDisbandResponse.from(
             teamService.disbandTeam(principal.getName(), request)
+        )
+    );
+  }
+
+  @PatchMapping("/{teamId}/restore")
+  public ResponseEntity<TeamRestoreResponse> restoreTeamRequest(
+      Principal principal,
+      @RequestParam(value = "restoreDt") @DateTimeFormat(pattern = "yyyy-MM-dd")
+      LocalDate restoreDt,
+      @PathVariable("teamId") Long teamId
+  ) {
+    return ResponseEntity.ok(
+        TeamRestoreResponse.from(
+            teamService.restoreTeam(principal.getName(), restoreDt, teamId)
         )
     );
   }

--- a/backend/src/main/java/com/api/backend/team/controller/TeamController.java
+++ b/backend/src/main/java/com/api/backend/team/controller/TeamController.java
@@ -1,5 +1,6 @@
 package com.api.backend.team.controller;
 
+import static com.api.backend.team.data.ResponseMessage.UPDATE_TEAM;
 import static com.api.backend.team.data.ResponseMessage.UPDATE_TEAM_PARTICIPANTS;
 
 import com.api.backend.team.data.dto.TeamCreateRequest;
@@ -10,7 +11,9 @@ import com.api.backend.team.data.dto.TeamDtoResponse;
 import com.api.backend.team.data.dto.TeamKickOutRequest;
 import com.api.backend.team.data.dto.TeamKickOutResponse;
 import com.api.backend.team.data.dto.TeamRestoreResponse;
-import com.api.backend.team.data.dto.UpdateTeamParticipantsResponse;
+import com.api.backend.team.data.dto.TeamUpdateRequest;
+import com.api.backend.team.data.dto.TeamParticipantsUpdateResponse;
+import com.api.backend.team.data.dto.TeamUpdateResponse;
 import com.api.backend.team.data.entity.Team;
 import com.api.backend.team.service.TeamService;
 import java.security.Principal;
@@ -60,14 +63,14 @@ public class TeamController {
   }
 
   @PostMapping("/{teamId}/{code}")
-  public ResponseEntity<UpdateTeamParticipantsResponse> updateTeamParticipantRequest(
+  public ResponseEntity<TeamParticipantsUpdateResponse> updateTeamParticipantRequest(
       @PathVariable("teamId") Long teamId,
       @PathVariable("code") String code,
       Principal principal
   ) {
     Team team = teamService.updateTeamParticipants(teamId, code, principal.getName());
     return ResponseEntity.ok(
-        UpdateTeamParticipantsResponse
+        TeamParticipantsUpdateResponse
             .builder().teamName(team.getName())
             .teamId(teamId)
             .message(team.getName() + UPDATE_TEAM_PARTICIPANTS)
@@ -123,4 +126,19 @@ public class TeamController {
         )
     );
   }
+
+  @PutMapping
+  public ResponseEntity<TeamUpdateResponse> updateTeamRequest(
+      @RequestBody @Valid TeamUpdateRequest teamUpdateRequest,
+      @RequestParam(value = "userId") String userId
+  ) {
+    return ResponseEntity.ok(
+        TeamUpdateResponse.from(
+            teamService.updateTeam(teamUpdateRequest, userId)
+        )
+    );
+  }
+
+
+
 }

--- a/backend/src/main/java/com/api/backend/team/data/ResponseMessage.java
+++ b/backend/src/main/java/com/api/backend/team/data/ResponseMessage.java
@@ -6,4 +6,6 @@ public class ResponseMessage {
   public static final String DISBANDING_TEAM = "팀이 해체중에 있습니다. 복구는 해당 날짜까지 가능합니다.";
   public static final String DISBAND_TEAM = "해당 팀은 이미 해체된 팀 입니다.";
   public static final String RESTORE_TEAM = "해당 팀이 복구되었습니다.";
+  public static final String UPDATE_TEAM = "해당 팀은 성공적으로 수정 되었습니다.";
+
 }

--- a/backend/src/main/java/com/api/backend/team/data/ResponseMessage.java
+++ b/backend/src/main/java/com/api/backend/team/data/ResponseMessage.java
@@ -3,4 +3,5 @@ package com.api.backend.team.data;
 public class ResponseMessage {
 
   public static final String UPDATE_TEAM_PARTICIPANTS = "에 참가했습니다.";
+  public static final String DISBANDING_TEAM = "팀이 해체중에 있습니다. 복구는 해당 날짜까지 가능합니다.";
 }

--- a/backend/src/main/java/com/api/backend/team/data/ResponseMessage.java
+++ b/backend/src/main/java/com/api/backend/team/data/ResponseMessage.java
@@ -4,4 +4,6 @@ public class ResponseMessage {
 
   public static final String UPDATE_TEAM_PARTICIPANTS = "에 참가했습니다.";
   public static final String DISBANDING_TEAM = "팀이 해체중에 있습니다. 복구는 해당 날짜까지 가능합니다.";
+  public static final String DISBAND_TEAM = "해당 팀은 이미 해체된 팀 입니다.";
+  public static final String RESTORE_TEAM = "해당 팀이 복구되었습니다.";
 }

--- a/backend/src/main/java/com/api/backend/team/data/dto/TeamDisbandRequest.java
+++ b/backend/src/main/java/com/api/backend/team/data/dto/TeamDisbandRequest.java
@@ -1,0 +1,18 @@
+package com.api.backend.team.data.dto;
+
+import javax.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@ToString
+public class TeamDisbandRequest {
+  @NotNull(message = "teamId는 비어있는 값입니다.")
+  private Long teamId;
+  @NotNull(message = "비밀번호를 입력해주세요")
+  private String password;
+}

--- a/backend/src/main/java/com/api/backend/team/data/dto/TeamDisbandResponse.java
+++ b/backend/src/main/java/com/api/backend/team/data/dto/TeamDisbandResponse.java
@@ -1,0 +1,33 @@
+package com.api.backend.team.data.dto;
+
+import static com.api.backend.team.data.ResponseMessage.DISBANDING_TEAM;
+
+import com.api.backend.team.data.entity.Team;
+import java.time.LocalDate;
+import javax.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@ToString
+@Builder
+public class TeamDisbandResponse {
+  @NotNull(message = "teamId는 비어있는 값입니다.")
+  private Long teamId;
+  private LocalDate reservationDt;
+  @NotNull(message = "비밀번호를 입력해주세요")
+  private String message;
+
+
+  public static TeamDisbandResponse from(Team team) {
+    return TeamDisbandResponse.builder()
+        .teamId(team.getTeamId())
+        .reservationDt(team.getRestorationDt())
+        .message(DISBANDING_TEAM).build();
+  }
+}

--- a/backend/src/main/java/com/api/backend/team/data/dto/TeamDtoResponse.java
+++ b/backend/src/main/java/com/api/backend/team/data/dto/TeamDtoResponse.java
@@ -1,0 +1,33 @@
+package com.api.backend.team.data.dto;
+
+
+import com.api.backend.team.data.entity.Team;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+import org.springframework.data.domain.Page;
+
+@NoArgsConstructor
+@Getter
+@AllArgsConstructor
+@Builder
+@ToString
+public class TeamDtoResponse {
+  private Long teamId;
+  private String name;
+  private String profileUrl;
+
+  public static TeamDtoResponse from(Team team) {
+    return TeamDtoResponse.builder()
+        .teamId(team.getTeamId())
+        .name(team.getName())
+        .profileUrl(team.getProfileUrl())
+        .build();
+  }
+
+  public static Page<TeamDtoResponse> fromDtos(Page<Team> teams){
+    return teams.map(TeamDtoResponse::from);
+  }
+}

--- a/backend/src/main/java/com/api/backend/team/data/dto/TeamKickOutResponse.java
+++ b/backend/src/main/java/com/api/backend/team/data/dto/TeamKickOutResponse.java
@@ -14,5 +14,6 @@ import lombok.ToString;
 public class TeamKickOutResponse {
   private Long teamId;
   private Long userId;
+  private String nickName;
   private String message;
 }

--- a/backend/src/main/java/com/api/backend/team/data/dto/TeamParticipantsUpdateResponse.java
+++ b/backend/src/main/java/com/api/backend/team/data/dto/TeamParticipantsUpdateResponse.java
@@ -1,0 +1,19 @@
+package com.api.backend.team.data.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@ToString
+public class TeamParticipantsUpdateResponse {
+
+  private Long teamId;
+  private String teamName;
+  private String message;
+}

--- a/backend/src/main/java/com/api/backend/team/data/dto/TeamRestoreResponse.java
+++ b/backend/src/main/java/com/api/backend/team/data/dto/TeamRestoreResponse.java
@@ -1,0 +1,28 @@
+package com.api.backend.team.data.dto;
+
+import static com.api.backend.team.data.ResponseMessage.DISBAND_TEAM;
+import static com.api.backend.team.data.ResponseMessage.RESTORE_TEAM;
+
+import com.api.backend.team.data.entity.Team;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor
+@Getter
+@AllArgsConstructor
+@Builder
+public class TeamRestoreResponse {
+  private Long teamId;
+  private String teamName;
+  private String message;
+
+  public static TeamRestoreResponse from(Team team) {
+    return TeamRestoreResponse.builder()
+        .teamId(team.getTeamId())
+        .teamName(team.getName())
+        .message(team.isDelete() ? DISBAND_TEAM : RESTORE_TEAM)
+        .build();
+  }
+}

--- a/backend/src/main/java/com/api/backend/team/data/dto/TeamUpdateRequest.java
+++ b/backend/src/main/java/com/api/backend/team/data/dto/TeamUpdateRequest.java
@@ -1,19 +1,14 @@
 package com.api.backend.team.data.dto;
 
 import lombok.AllArgsConstructor;
-import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import lombok.ToString;
 
 @Getter
 @NoArgsConstructor
 @AllArgsConstructor
-@Builder
-@ToString
-public class UpdateTeamParticipantsResponse {
-
+public class TeamUpdateRequest {
   private Long teamId;
   private String teamName;
-  private String message;
+  private String profileUrl;
 }

--- a/backend/src/main/java/com/api/backend/team/data/dto/TeamUpdateResponse.java
+++ b/backend/src/main/java/com/api/backend/team/data/dto/TeamUpdateResponse.java
@@ -1,0 +1,29 @@
+package com.api.backend.team.data.dto;
+
+import static com.api.backend.team.data.ResponseMessage.UPDATE_TEAM;
+
+import com.api.backend.team.data.entity.Team;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class TeamUpdateResponse {
+  private Long teamId;
+  private String teamName;
+  private String profileUrl;
+  private String message;
+
+  public static TeamUpdateResponse from(Team team) {
+    return TeamUpdateResponse.builder()
+        .profileUrl(team.getProfileUrl())
+        .message(UPDATE_TEAM)
+        .teamName(team.getName())
+        .teamId(team.getTeamId())
+        .build();
+  }
+}

--- a/backend/src/main/java/com/api/backend/team/data/entity/Team.java
+++ b/backend/src/main/java/com/api/backend/team/data/entity/Team.java
@@ -54,4 +54,13 @@ public class Team extends BaseEntity {
     this.restorationDt = LocalDate.now().plusDays(30);
   }
 
+  public void updateIsDelete() {
+    this.isDelete = true;
+  }
+
+  public void deleteReservationTime() {
+    this.restorationDt = null;
+  }
+
+
 }

--- a/backend/src/main/java/com/api/backend/team/data/entity/Team.java
+++ b/backend/src/main/java/com/api/backend/team/data/entity/Team.java
@@ -30,7 +30,7 @@ public class Team extends BaseEntity {
   @GeneratedValue(strategy = GenerationType.IDENTITY)
   private Long teamId;
   private String name;
-  private LocalDateTime restorationTime;
+  private LocalDate restorationDt;
   private boolean isDelete;
   private int memberLimit;
   private String inviteLink;

--- a/backend/src/main/java/com/api/backend/team/data/entity/Team.java
+++ b/backend/src/main/java/com/api/backend/team/data/entity/Team.java
@@ -3,7 +3,7 @@ package com.api.backend.team.data.entity;
 import com.api.backend.global.domain.BaseEntity;
 import com.api.backend.documents.data.entity.Documents;
 import com.api.backend.schedule.data.enetity.Schedule;
-import java.time.LocalDateTime;
+import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
@@ -50,4 +50,8 @@ public class Team extends BaseEntity {
     this.inviteLink = this.teamId +
         "/" + UUID.randomUUID();
   }
+  public void updateReservationTime() {
+    this.restorationDt = LocalDate.now().plusDays(30);
+  }
+
 }

--- a/backend/src/main/java/com/api/backend/team/data/entity/Team.java
+++ b/backend/src/main/java/com/api/backend/team/data/entity/Team.java
@@ -38,12 +38,15 @@ public class Team extends BaseEntity {
   private String profileUrl;
 
   @OneToMany(mappedBy = "team")
+  @Builder.Default
   private List<TeamParticipants> teamParticipants = new ArrayList<>();
 
   @OneToMany(mappedBy = "team")
+  @Builder.Default
   private List<Schedule> schedules = new ArrayList<>();
 
   @OneToMany(mappedBy = "team")
+  @Builder.Default
   private List<Documents> documents = new ArrayList<>();
 
 

--- a/backend/src/main/java/com/api/backend/team/data/entity/Team.java
+++ b/backend/src/main/java/com/api/backend/team/data/entity/Team.java
@@ -3,6 +3,7 @@ package com.api.backend.team.data.entity;
 import com.api.backend.global.domain.BaseEntity;
 import com.api.backend.documents.data.entity.Documents;
 import com.api.backend.schedule.data.enetity.Schedule;
+import com.api.backend.team.data.dto.TeamUpdateRequest;
 import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.List;
@@ -62,5 +63,12 @@ public class Team extends BaseEntity {
     this.restorationDt = null;
   }
 
-
+  public void updateNameOrProfileUrl(TeamUpdateRequest teamUpdateRequest) {
+    if (!teamUpdateRequest.getTeamName().equals(this.name)) {
+      this.name = teamUpdateRequest.getTeamName();
+    }
+    if (!teamUpdateRequest.getProfileUrl().equals(this.profileUrl)) {
+      this.profileUrl = teamUpdateRequest.getProfileUrl();
+    }
+  }
 }

--- a/backend/src/main/java/com/api/backend/team/data/repository/TeamParticipantsRepository.java
+++ b/backend/src/main/java/com/api/backend/team/data/repository/TeamParticipantsRepository.java
@@ -1,12 +1,14 @@
 package com.api.backend.team.data.repository;
 
 import com.api.backend.team.data.entity.TeamParticipants;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface TeamParticipantsRepository extends JpaRepository<TeamParticipants,Long> {
 
+  Optional<TeamParticipants> findByTeam_TeamIdAndMember_MemberId(Long teamId, Long userId);
 
   boolean existsByTeam_TeamIdAndMember_MemberId(Long teamId,Long userId);
 }

--- a/backend/src/main/java/com/api/backend/team/data/repository/TeamRepository.java
+++ b/backend/src/main/java/com/api/backend/team/data/repository/TeamRepository.java
@@ -7,4 +7,5 @@ import org.springframework.stereotype.Repository;
 @Repository
 public interface TeamRepository extends JpaRepository<Team,Long> {
 
+  boolean existsByTeamIdAndIsDelete(Long teamId, boolean isDelete);
 }

--- a/backend/src/main/java/com/api/backend/team/data/repository/TeamRepository.java
+++ b/backend/src/main/java/com/api/backend/team/data/repository/TeamRepository.java
@@ -1,6 +1,8 @@
 package com.api.backend.team.data.repository;
 
 import com.api.backend.team.data.entity.Team;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
@@ -8,4 +10,6 @@ import org.springframework.stereotype.Repository;
 public interface TeamRepository extends JpaRepository<Team,Long> {
 
   boolean existsByTeamIdAndIsDelete(Long teamId, boolean isDelete);
+
+  Page<Team> findAllByTeamParticipants_Member_MemberIdAndIsDelete(Long memberId, boolean isDelete, Pageable pageable);
 }

--- a/backend/src/main/java/com/api/backend/team/service/TeamService.java
+++ b/backend/src/main/java/com/api/backend/team/service/TeamService.java
@@ -30,6 +30,8 @@ import com.api.backend.team.data.type.TeamRole;
 import java.time.LocalDate;
 import java.util.Objects;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -217,4 +219,12 @@ public class TeamService {
     team.deleteReservationTime();
     return team;
   }
+
+  public Page<Team> getTeams(String userId, Pageable pageable) {
+    return teamRepository
+        .findAllByTeamParticipants_Member_MemberIdAndIsDelete(
+            Long.valueOf(userId), DELETE_FALSE_FLAG, pageable
+        );
+  }
+
 }

--- a/backend/src/main/java/com/api/backend/team/service/TeamService.java
+++ b/backend/src/main/java/com/api/backend/team/service/TeamService.java
@@ -6,7 +6,6 @@ import static com.api.backend.global.exception.type.ErrorCode.TEAM_NOT_FOUND_EXC
 import static com.api.backend.global.exception.type.ErrorCode.TEAM_PARTICIPANTS_EXIST_EXCEPTION;
 import static com.api.backend.global.exception.type.ErrorCode.TEAM_PARTICIPANTS_NOT_FOUND_EXCEPTION;
 import static com.api.backend.global.exception.type.ErrorCode.TEAM_PARTICIPANTS_NOT_VALID_EXCEPTION;
-import static com.api.backend.global.exception.type.ErrorCode.TOKEN_EXPIRED_EXCEPTION;
 
 import com.api.backend.global.exception.CustomException;
 import com.api.backend.member.data.entity.Member;
@@ -66,9 +65,7 @@ public class TeamService {
 
   public String getTeamUrl(Long teamId,String userId) {
     Team team = getTeam(teamId);
-    if (userId == null) {
-      throw new CustomException(TOKEN_EXPIRED_EXCEPTION);
-    }
+
     if (!teamParticipantsRepository.existsByTeam_TeamIdAndMember_MemberId(teamId, Long.valueOf(userId))) {
       throw new CustomException(TEAM_PARTICIPANTS_NOT_VALID_EXCEPTION);
     }
@@ -102,7 +99,7 @@ public class TeamService {
   }
 
   @Transactional
-  public TeamKickOutResponse kickOutTeamParticipants(TeamKickOutRequest request) {
+  public TeamKickOutResponse kickOutTeamParticipants(TeamKickOutRequest request, String userId) {
     Team team = getTeam(request.getTeamId());
 
     TeamParticipants teamParticipants = team.getTeamParticipants().stream()

--- a/backend/src/main/java/com/api/backend/team/service/TeamService.java
+++ b/backend/src/main/java/com/api/backend/team/service/TeamService.java
@@ -22,6 +22,7 @@ import com.api.backend.team.data.dto.TeamCreateResponse;
 import com.api.backend.team.data.dto.TeamDisbandRequest;
 import com.api.backend.team.data.dto.TeamKickOutRequest;
 import com.api.backend.team.data.dto.TeamKickOutResponse;
+import com.api.backend.team.data.dto.TeamUpdateRequest;
 import com.api.backend.team.data.entity.Team;
 import com.api.backend.team.data.entity.TeamParticipants;
 import com.api.backend.team.data.repository.TeamParticipantsRepository;
@@ -227,4 +228,21 @@ public class TeamService {
         );
   }
 
+  @Transactional
+  public Team updateTeam(TeamUpdateRequest teamUpdateRequest, String userId) {
+    TeamParticipants teamParticipants = teamParticipantsRepository
+        .findByTeam_TeamIdAndMember_MemberId(teamUpdateRequest.getTeamId(), Long.valueOf(userId))
+        .orElseThrow(() -> new CustomException(TEAM_PARTICIPANTS_NOT_FOUND_EXCEPTION));
+
+    if (!teamParticipants.getTeamRole().equals(TeamRole.READER)) {
+      throw new CustomException(TEAM_PARTICIPANT_NOT_VALID_READER_EXCEPTION);
+    }
+
+    Team team = teamParticipants.getTeam();
+
+    isDeletedCheck(team);
+
+    team.updateNameOrProfileUrl(teamUpdateRequest);
+    return team;
+  }
 }

--- a/backend/src/test/java/com/api/backend/team/service/TeamServiceTest.java
+++ b/backend/src/test/java/com/api/backend/team/service/TeamServiceTest.java
@@ -38,6 +38,10 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 
 @ExtendWith(MockitoExtension.class)
 class TeamServiceTest {
@@ -535,5 +539,34 @@ class TeamServiceTest {
     //then
     assertEquals(result.getErrorCode().getCode(),TEAM_NOT_DELETEING_EXCEPTION.getCode());
     assertEquals(result.getErrorCode().getErrorMessage(),TEAM_NOT_DELETEING_EXCEPTION.getErrorMessage());
+  }
+
+  @Test
+  @DisplayName("자신이 속한 팀 조회시 팀 해체여부가 false 인 것만 받아온다.")
+  void getTimes(){
+    //given
+    String userId = "1";
+    Pageable pageable = PageRequest.of(0,10);
+    List<Team> teams = new ArrayList<>();
+    for (int i = 0; i < 3; i++) {
+      teams.add(
+          Team.builder()
+              .teamId((long) i)
+              .build()
+      );
+    }
+    Page<Team> teamPage = new PageImpl<>(teams);
+    when(teamRepository.findAllByTeamParticipants_Member_MemberIdAndIsDelete(
+        anyLong(), anyBoolean(), any()
+    )).thenReturn(teamPage);
+
+    //when
+    Page<Team> result = teamService.getTeams(userId, pageable);
+
+    //then
+    List<Team> resultTeam = result.getContent();
+    for (int i = 0; i < 3; i++) {
+      assertEquals(resultTeam.get(i).getTeamId(),i);
+    }
   }
 }

--- a/backend/src/test/java/com/api/backend/team/service/TeamServiceTest.java
+++ b/backend/src/test/java/com/api/backend/team/service/TeamServiceTest.java
@@ -23,6 +23,7 @@ import com.api.backend.member.data.entity.Member;
 import com.api.backend.team.data.dto.TeamDisbandRequest;
 import com.api.backend.team.data.dto.TeamKickOutRequest;
 import com.api.backend.team.data.dto.TeamKickOutResponse;
+import com.api.backend.team.data.dto.TeamUpdateRequest;
 import com.api.backend.team.data.entity.Team;
 import com.api.backend.team.data.entity.TeamParticipants;
 import com.api.backend.team.data.repository.TeamParticipantsRepository;
@@ -568,5 +569,31 @@ class TeamServiceTest {
     for (int i = 0; i < 3; i++) {
       assertEquals(resultTeam.get(i).getTeamId(),i);
     }
+  }
+
+  @Test
+  @DisplayName("팀 내용수정 service로직")
+  void updateTeam(){
+    //given
+    TeamUpdateRequest teamUpdateRequest =
+        new TeamUpdateRequest(1L, "test", "testProfile");
+    String userId = "1";
+    Team team = Team.builder()
+        .name("test1")
+        .profileUrl("test").build();
+
+    TeamParticipants teamParticipants = TeamParticipants.builder()
+        .team(team)
+        .teamRole(TeamRole.READER)
+        .build();
+    when(teamParticipantsRepository.findByTeam_TeamIdAndMember_MemberId(anyLong(), anyLong()))
+        .thenReturn(Optional.of(teamParticipants));
+
+    //when
+    Team result = teamService.updateTeam(teamUpdateRequest, userId);
+
+    //then
+    assertEquals(result.getName(),teamUpdateRequest.getTeamName());
+    assertEquals(result.getProfileUrl(),teamUpdateRequest.getProfileUrl());
   }
 }


### PR DESCRIPTION
### 변경 내용

AS-IS
- 각 적용 마다 principal 미적용
- 기존 team api

TO-BE
- 팀 해체 api
- 팀 복구 api
- 팀 조회(list) api
- 팀 수정 api
- 컬럼이름 변경
- 기존 team 관련 api 검증 추가

### 테스트
<!-- 본 변경사항이 테스트가 되었는지 기술해주세요 --> 
* [ ] 테스트 코드
* [ ] API 테스트

### 관련 이슈
@Builder will ignore the initializing expression entirely. If you want the initializing expression to serve as default, add @Builder.Default. If it is not supposed to be settable during building, make the field final.

저희 각 연관관계에서 잠재적 오류가 있어서 방지했습니다. 

[해당 자료입니다.](https://lokie.tistory.com/24)

### 변경 사항 검토
* [ ] api 문서 업데이트

### 특이 사항

### 스크린샷 (선택 사항)
![image](https://github.com/100backfro/teammate/assets/48014869/dda12251-af86-4f4e-b73d-476c99ca5d48)