### PR TITLE
Feat/team create page

### DIFF
--- a/frontend/src/components/Home/HomeContent.tsx
+++ b/frontend/src/components/Home/HomeContent.tsx
@@ -1,7 +1,6 @@
 import React from "react";
 import { useRecoilValue } from "recoil";
-import { teamListState } from "../../state/authState";
-import { useSearchState } from "../../state/authState";
+import { teamListState, useSearchState } from "../../state/authState";
 
 const HomeContent = () => {
   const teamList = useRecoilValue(teamListState);

--- a/frontend/src/components/Home/HomeSearchBar.tsx
+++ b/frontend/src/components/Home/HomeSearchBar.tsx
@@ -1,31 +1,8 @@
 import React from "react";
-import { useRecoilState } from "recoil";
-import {
-  searchState,
-  teamListState,
-  useSearchState,
-} from "../../state/authState";
+import { useSearchState } from "../../state/authState";
 
 export default function HomeSearchBar() {
   const { search, setSearch, handleSearch } = useSearchState();
-  // const [searchTeam, setSearchTeam] = useRecoilState(searchState);
-  // const setTeamList = useRecoilState(teamListState)[1];
-
-  // const handleSearch = async () => {
-  //   // 검색을 수행하거나 다른 작업을 수행할 수 있습니다.
-  //   console.log("검색어:", searchTeam);
-
-  //   const searchResults = await fetchTeamsBySearchTeam(searchTeam);
-  //   setTeamList(searchResults);
-  // };
-
-  // // 실제 서버와 통신하여 검색 결과를 가져오는 함수
-  // const fetchTeamsBySearchTeam = async (searchTeam: string) => {
-  //   const response = await fetch(`/api/teams?search=${searchTeam}`);
-  //   const data = await response.json();
-
-  //   return data;
-  // };
 
   return (
     <div>

--- a/frontend/src/components/Login/SignIn.tsx
+++ b/frontend/src/components/Login/SignIn.tsx
@@ -3,7 +3,11 @@ import axios from "axios";
 import { useNavigate } from "react-router-dom";
 import { StyledContainer, StyledFormItem } from "../../styles/SignInStyled";
 import { useRecoilState } from "recoil";
-import { isAuthenticatedState, saveAccessToken } from "../../state/authState";
+import {
+  isAuthenticatedState,
+  saveAccessToken,
+  useUser,
+} from "../../state/authState";
 
 const SignIn = () => {
   const [email, setEmail] = useState("");
@@ -11,12 +15,13 @@ const SignIn = () => {
   const [error, setError] = useState("");
   const [isAuthenticated, setIsAuthenticated] =
     useRecoilState(isAuthenticatedState);
+  const { setUser } = useUser();
   const navigate = useNavigate();
 
   // Mock users data for testing
   const mockUsers = [
-    { id: "user1@example.com", password: "password1" },
-    { id: "user2@example.com", password: "password2" },
+    { id: "user1@example.com", password: "password1", name: "김팀장" },
+    { id: "user2@example.com", password: "password2", name: "이팀원" },
   ];
 
   const handleLogout = () => {
@@ -52,6 +57,7 @@ const SignIn = () => {
         saveAccessToken(accessToken);
         setIsAuthenticated(true);
 
+        setUser({ id: email, name: user.name });
         navigate("/homeview");
       } else {
         setError("올바른 이메일 또는 비밀번호를 입력하세요.");

--- a/frontend/src/components/Profile/Profile.tsx
+++ b/frontend/src/components/Profile/Profile.tsx
@@ -1,5 +1,0 @@
-import React from "react";
-
-export default function Profile() {
-  return <div></div>;
-}

--- a/frontend/src/components/Profile/TeamProfile.tsx
+++ b/frontend/src/components/Profile/TeamProfile.tsx
@@ -1,4 +1,5 @@
 import React from "react";
+import styled from "styled-components";
 
 interface TeamProfileProps {
   selectedTeam: string | null;
@@ -9,6 +10,53 @@ interface TeamProfileProps {
   handleUpdateProfile: (image: string | null, nickname: string) => void;
 }
 
+const TeamProfileContainer = styled.div`
+  padding: 20px;
+  border-radius: 8px;
+  margin: auto;
+  width: 25%;
+`;
+
+const TeamProfileTitle = styled.h3`
+  font-size: 1.5rem;
+  margin-bottom: 10px;
+  text-align: center;
+  color: #333;
+`;
+
+const ImageUploadContainer = styled.div`
+  margin-bottom: 15px;
+
+  input {
+    margin-bottom: 10px;
+  }
+
+  img {
+    max-width: 100px;
+    max-height: 100px;
+  }
+`;
+
+const NicknameContainer = styled.div`
+  input {
+    margin-bottom: 10px;
+    padding: 5px;
+  }
+`;
+const UpdateButton = styled.button`
+  flex: 1;
+  margin-left: 10px;
+  margin: 0 auto;
+  padding: 8px;
+  background-color: #a3cca3;
+  color: #333333;
+  cursor: pointer;
+
+  &:hover {
+    background-color: #cccccc;
+  }
+`;
+
 const TeamProfile: React.FC<TeamProfileProps> = ({
   selectedTeam,
   selectedImage,
@@ -18,13 +66,14 @@ const TeamProfile: React.FC<TeamProfileProps> = ({
   handleUpdateProfile,
 }) => {
   return (
-    <div>
+    <TeamProfileContainer>
       {selectedTeam && (
         <div>
-          <h3>{selectedTeam} 팀 프로필</h3>
-          <div>
-            <label htmlFor="imageUpload">이미지 업로드:</label>
+          <TeamProfileTitle>{selectedTeam} 팀 프로필</TeamProfileTitle>
+          <br />
+          <ImageUploadContainer>
             <input
+              title="imgupload"
               type="file"
               id="imageUpload"
               accept="image/*"
@@ -32,31 +81,27 @@ const TeamProfile: React.FC<TeamProfileProps> = ({
             />
             {selectedImage && (
               <div>
-                <img
-                  src={selectedImage}
-                  alt="Selected"
-                  style={{ maxWidth: "100px", maxHeight: "100px" }}
-                />
+                <img src={selectedImage} alt="Selected" />
               </div>
             )}
-          </div>
-          <div>
-            <label htmlFor="nickname">닉네임 입력:</label>
+          </ImageUploadContainer>
+          <NicknameContainer>
             <input
               type="text"
+              placeholder="닉네임 입력"
               id="nickname"
               value={nickname}
               onChange={handleNicknameChange}
             />
-            <button
+            <UpdateButton
               onClick={() => handleUpdateProfile(selectedImage, nickname)}
             >
               변경 하기
-            </button>
-          </div>
+            </UpdateButton>
+          </NicknameContainer>
         </div>
       )}
-    </div>
+    </TeamProfileContainer>
   );
 };
 

--- a/frontend/src/components/Profile/TeamProfile.tsx
+++ b/frontend/src/components/Profile/TeamProfile.tsx
@@ -1,0 +1,63 @@
+import React from "react";
+
+interface TeamProfileProps {
+  selectedTeam: string | null;
+  selectedImage: string | null;
+  nickname: string;
+  handleImageUpload: (e: React.ChangeEvent<HTMLInputElement>) => void;
+  handleNicknameChange: (e: React.ChangeEvent<HTMLInputElement>) => void;
+  handleUpdateProfile: (image: string | null, nickname: string) => void;
+}
+
+const TeamProfile: React.FC<TeamProfileProps> = ({
+  selectedTeam,
+  selectedImage,
+  nickname,
+  handleImageUpload,
+  handleNicknameChange,
+  handleUpdateProfile,
+}) => {
+  return (
+    <div>
+      {selectedTeam && (
+        <div>
+          <h3>{selectedTeam} 팀 프로필</h3>
+          <div>
+            <label htmlFor="imageUpload">이미지 업로드:</label>
+            <input
+              type="file"
+              id="imageUpload"
+              accept="image/*"
+              onChange={handleImageUpload}
+            />
+            {selectedImage && (
+              <div>
+                <img
+                  src={selectedImage}
+                  alt="Selected"
+                  style={{ maxWidth: "100px", maxHeight: "100px" }}
+                />
+              </div>
+            )}
+          </div>
+          <div>
+            <label htmlFor="nickname">닉네임 입력:</label>
+            <input
+              type="text"
+              id="nickname"
+              value={nickname}
+              onChange={handleNicknameChange}
+            />
+            <button
+              onClick={() => handleUpdateProfile(selectedImage, nickname)}
+            >
+              변경 하기
+            </button>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default TeamProfile;

--- a/frontend/src/components/Profile/UserProfile.tsx
+++ b/frontend/src/components/Profile/UserProfile.tsx
@@ -1,0 +1,47 @@
+// UserProfile.js
+
+import React from "react";
+import { User, Team } from "../../state/authState"; // User 타입을 import
+
+interface UserProfileProps {
+  user: User | null;
+  teamList: Team[];
+  selectedTeam: string | null;
+  handleTeamSelect: (event: React.ChangeEvent<HTMLSelectElement>) => void;
+}
+
+const UserProfile: React.FC<UserProfileProps> = ({
+  user,
+  teamList,
+  selectedTeam,
+  handleTeamSelect,
+}) => {
+  return (
+    <div>
+      <h2>내 프로필</h2>
+      {user && (
+        <div>
+          <p>이름: {user.name}</p>
+          <p>Email: {user.id}</p>
+          <label htmlFor="teamSelect">소속 팀 선택:</label>
+          <select
+            id="teamSelect"
+            value={selectedTeam || ""}
+            onChange={handleTeamSelect}
+          >
+            <option value="" disabled>
+              팀을 선택하세요
+            </option>
+            {teamList.map((team) => (
+              <option key={team.name} value={team.name}>
+                {team.name}
+              </option>
+            ))}
+          </select>
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default UserProfile;

--- a/frontend/src/components/Profile/UserProfile.tsx
+++ b/frontend/src/components/Profile/UserProfile.tsx
@@ -2,6 +2,7 @@
 
 import React from "react";
 import { User, Team } from "../../state/authState"; // User 타입을 import
+import styled from "styled-components";
 
 interface UserProfileProps {
   user: User | null;
@@ -10,6 +11,36 @@ interface UserProfileProps {
   handleTeamSelect: (event: React.ChangeEvent<HTMLSelectElement>) => void;
 }
 
+const UserProfileContainer = styled.div`
+  padding: 20px;
+  border-radius: 8px;
+  margin: auto;
+  width: 25%;
+`;
+
+const UserProfileTitle = styled.h2`
+  font-size: 1.5rem;
+  margin-bottom: 10px;
+  text-align: center;
+`;
+
+const UserProfileInfo = styled.div`
+  p {
+    margin: 0;
+    margin-bottom: 15px;
+    text-align: left;
+  }
+
+  label {
+    margin-right: 10px;
+  }
+
+  select {
+    margin-left: 10px;
+    padding: 5px;
+  }
+`;
+
 const UserProfile: React.FC<UserProfileProps> = ({
   user,
   teamList,
@@ -17,10 +48,11 @@ const UserProfile: React.FC<UserProfileProps> = ({
   handleTeamSelect,
 }) => {
   return (
-    <div>
-      <h2>내 프로필</h2>
+    <UserProfileContainer>
+      <UserProfileTitle>내 프로필</UserProfileTitle>
+      <br />
       {user && (
-        <div>
+        <UserProfileInfo>
           <p>이름: {user.name}</p>
           <p>Email: {user.id}</p>
           <label htmlFor="teamSelect">소속 팀 선택:</label>
@@ -38,9 +70,9 @@ const UserProfile: React.FC<UserProfileProps> = ({
               </option>
             ))}
           </select>
-        </div>
+        </UserProfileInfo>
       )}
-    </div>
+    </UserProfileContainer>
   );
 };
 

--- a/frontend/src/components/TeamCreate/TeamInfo.tsx
+++ b/frontend/src/components/TeamCreate/TeamInfo.tsx
@@ -6,6 +6,13 @@ import {
   teamListState,
 } from "../../state/authState";
 import { useNavigate } from "react-router-dom";
+import {
+  StyledContainer,
+  StyledFormItem,
+  StyledImagePreview,
+  StyledErrorMessage,
+  StyledHeading,
+} from "../../styles/TeamInfoStyled";
 
 export default function TeamInfo() {
   const [teamName, setTeamName] = useRecoilState(teamNameState);
@@ -74,9 +81,9 @@ export default function TeamInfo() {
   };
 
   return (
-    <div>
-      <h2>팀 생성</h2>
-      <div>
+    <StyledContainer>
+      <StyledHeading>팀 생성</StyledHeading>
+      <StyledFormItem>
         <label htmlFor="teamName">팀 이름</label>
         <input
           type="text"
@@ -91,8 +98,8 @@ export default function TeamInfo() {
         {teamList.some((team) => team.name === teamName) && (
           <div style={{ color: "red" }}>이미 있는 팀 이름입니다.</div>
         )}
-      </div>
-      <div style={{ display: "flex", alignItems: "center" }}>
+      </StyledFormItem>
+      <StyledFormItem>
         <label htmlFor="teamSize">인원 수</label>
         <select
           id="teamSize"
@@ -116,20 +123,16 @@ export default function TeamInfo() {
           accept="image/*"
           onChange={handleImageUpload}
         />
-      </div>
+      </StyledFormItem>
       {selectedImage && (
-        <div>
-          <img
-            src={selectedImage}
-            alt="Selected"
-            style={{ maxWidth: "100px", maxHeight: "100px" }}
-          />
-        </div>
+        <StyledImagePreview>
+          <img src={selectedImage} alt="Selected" />
+        </StyledImagePreview>
       )}
-      <div>
+      <StyledFormItem>
         <button onClick={handleCreateTeam}>생성하기</button>
-        {error && <div style={{ color: "red" }}>{error}</div>}
-      </div>
-    </div>
+        {error && <StyledErrorMessage>{error}</StyledErrorMessage>}
+      </StyledFormItem>
+    </StyledContainer>
   );
 }

--- a/frontend/src/components/TeamCreate/TeamInfo.tsx
+++ b/frontend/src/components/TeamCreate/TeamInfo.tsx
@@ -1,6 +1,4 @@
-// TeamInfo.tsx
-
-import React, { useState } from "react";
+import React, { useState, useEffect } from "react";
 import { useRecoilState } from "recoil";
 import {
   teamNameState,
@@ -16,16 +14,37 @@ export default function TeamInfo() {
   );
   const [selectedImage, setSelectedImage] = useState<string | null>(null);
   const [teamList, setTeamList] = useRecoilState(teamListState);
+  const [error, setError] = useState<string | null>(null); // 에러 상태 추가
   const navigate = useNavigate();
 
-  const handleCreateTeam = () => {
-    // TODO: 팀 생성 로직을 구현하세요.
-    // teamName, selectedTeamSize, selectedImage를 이용하여 팀을 생성하는 로직을 작성합니다.
-    console.log("팀 생성 로직 수행");
-    console.log("팀 이름:", teamName);
-    console.log("인원 수:", selectedTeamSize);
-    console.log("선택된 이미지:", selectedImage);
+  // 페이지 로드 시 초기값 설정
+  useEffect(() => {
+    setTeamName("");
+    setSelectedTeamSize("");
+    setSelectedImage(null);
+    setError(null);
+  }, []);
 
+  const handleCreateTeam = () => {
+    // 입력값 확인
+    let errorMessage = "";
+
+    if (!teamName) {
+      errorMessage = "팀 이름을 입력해주세요.";
+    } else if (teamList.some((team) => team.name === teamName)) {
+      errorMessage = "이미 있는 팀 이름입니다.";
+    } else if (!selectedTeamSize) {
+      errorMessage = "인원 수를 선택해주세요.";
+    } else if (!selectedImage) {
+      errorMessage = "이미지를 업로드해주세요.";
+    }
+
+    if (errorMessage) {
+      setError(errorMessage);
+      return;
+    }
+
+    setError(null); // 에러가 없다면 에러 상태 초기화
     // 생성한 팀 정보를 Recoil 상태에 추가
     const newTeam = {
       name: teamName,
@@ -63,16 +82,29 @@ export default function TeamInfo() {
           type="text"
           id="teamName"
           value={teamName}
-          onChange={(e) => setTeamName(e.target.value)}
+          onChange={(e) => {
+            setTeamName(e.target.value);
+            setError(null); // 팀 이름이 변경될 때 에러 상태 초기화
+          }}
         />
+        {/* 이미 있는 팀 이름인 경우 에러 메시지 표시 */}
+        {teamList.some((team) => team.name === teamName) && (
+          <div style={{ color: "red" }}>이미 있는 팀 이름입니다.</div>
+        )}
       </div>
       <div style={{ display: "flex", alignItems: "center" }}>
         <label htmlFor="teamSize">인원 수</label>
         <select
           id="teamSize"
           value={selectedTeamSize}
-          onChange={(e) => setSelectedTeamSize(e.target.value)}
+          onChange={(e) => {
+            setSelectedTeamSize(e.target.value);
+            setError(null); // 인원 수 선택 시 에러 상태 초기화
+          }}
         >
+          <option value="" disabled>
+            선택하세요
+          </option>
           <option value="1-9">1~9명</option>
           <option value="10-99">10~99명</option>
           <option value="100+">100명 이상</option>
@@ -96,6 +128,7 @@ export default function TeamInfo() {
       )}
       <div>
         <button onClick={handleCreateTeam}>생성하기</button>
+        {error && <div style={{ color: "red" }}>{error}</div>}
       </div>
     </div>
   );

--- a/frontend/src/router/router.tsx
+++ b/frontend/src/router/router.tsx
@@ -6,7 +6,6 @@ import SignUp from "../components/Join/SignUp";
 import Index from "../views/Index";
 import KakaoLogin from "../components/Login/KakaoLogin";
 import Home from "../components/Home/HomeContent";
-import Profile from "../components/Profile/Profile";
 import Mypage from "../components/Profile/Mypage";
 import HomeView from "../views/HomeView";
 import TeamCreateView from "../views/TeamCreateView";
@@ -21,7 +20,6 @@ const Router = () => {
       <Route path="/kakaoLogin" element={<KakaoLogin />} />
       <Route path="/home" element={<Home />} />
       <Route path="/homeview" element={<HomeView />} />
-      <Route path="/profile" element={<Profile />} />
       <Route path="/mypage" element={<Mypage />} />
       <Route path="/teamcreateview" element={<TeamCreateView />} />
       <Route />

--- a/frontend/src/state/authState.tsx
+++ b/frontend/src/state/authState.tsx
@@ -1,15 +1,13 @@
-// authState.ts
-
-import { atom, useRecoilState } from "recoil";
+import { atom, useRecoilState, selector } from "recoil";
 import { useEffect } from "react";
 
-// 로그인 상태를 저장하는 atom
+// Authentication State
 export const isAuthenticatedState = atom({
   key: "isAuthenticatedState",
   default: Boolean(localStorage.getItem("accessToken")),
 });
 
-// accessToken을 저장하는 함수
+// Access Token Functions
 export const saveAccessToken = (token: string | null) => {
   if (token) {
     localStorage.setItem("accessToken", token);
@@ -18,16 +16,14 @@ export const saveAccessToken = (token: string | null) => {
   }
 };
 
-// 로그아웃 함수
 export const logout = () => {
   localStorage.removeItem("accessToken");
 };
 
-// 홈화면 검색창
+// Home Screen Search State
 export const searchState = atom({
   key: "searchState",
   default: (() => {
-    // 로컬 스토리지에서 검색어 가져오기
     const storedSearch = localStorage.getItem("search");
     return storedSearch || "";
   })() as string,
@@ -36,9 +32,9 @@ export const searchState = atom({
 export const useSearchState = () => {
   const [search, setSearch] = useRecoilState(searchState);
   const [teamList, setTeamList] = useRecoilState(teamListState);
+
   const handleSearch = async (searchTerm: string) => {
     console.log("검색어:", searchTerm);
-
     const searchResults = await fetchTeamsBySearchTeam(searchTerm);
     setTeamList(searchResults);
   };
@@ -52,7 +48,7 @@ export const useSearchState = () => {
   return { search, setSearch, handleSearch, teamList, setTeamList };
 };
 
-// 팀 생성창
+// Team Creation State
 export const teamNameState = atom({
   key: "teamNameState",
   default: (() => {
@@ -69,6 +65,7 @@ export const selectedTeamSizeState = atom({
   })(),
 });
 
+// Team List State
 export interface Team {
   name: string;
   size: string;
@@ -77,12 +74,10 @@ export interface Team {
 
 export const teamListState = atom<Team[]>({
   key: "teamListState",
-  default: [], // 초기값을 빈 배열로 설정
+  default: [],
 
-  // Recoil 초기화 함수 사용
   effects_UNSTABLE: [
     ({ setSelf }) => {
-      // 로컬 스토리지에서 팀 목록 가져오기
       const storedTeamList = localStorage.getItem("teamList");
       if (storedTeamList) {
         setSelf(JSON.parse(storedTeamList));
@@ -91,7 +86,15 @@ export const teamListState = atom<Team[]>({
   ],
 });
 
-// 마이페이지 (사용자 정보)
+// Selected Team State for MyPage
+export const selectedTeamState = atom({
+  key: "selectedTeam",
+  default: "",
+});
+
+export const useSelectedTeamState = () => useRecoilState(selectedTeamState);
+
+// User State and Functions
 export interface User {
   id: string;
   name: string;
@@ -99,10 +102,10 @@ export interface User {
 
 export const userState = atom<User | null>({
   key: "userState",
-  default: null, // 직접 값을 지정
+  default: null,
+
   effects_UNSTABLE: [
     ({ onSet }) => {
-      // 아톰 값이 변경될 때 로컬 스토리지에 사용자 정보 저장
       onSet((newValue) => {
         localStorage.setItem("user", JSON.stringify(newValue));
       });
@@ -115,12 +118,10 @@ export const useUser = () => {
 
   const saveUser = (loggedInUser: User) => {
     setUser(loggedInUser);
-    // 사용자 정보를 localStorage에 저장
     localStorage.setItem("user", JSON.stringify(loggedInUser));
   };
 
   useEffect(() => {
-    // 앱이 로드될 때 사용자 정보를 localStorage에서 복구
     const storedUser = localStorage.getItem("user");
     if (storedUser) {
       setUser(JSON.parse(storedUser));
@@ -129,3 +130,5 @@ export const useUser = () => {
 
   return { user, setUser, saveUser };
 };
+
+// MyPage State

--- a/frontend/src/state/authState.tsx
+++ b/frontend/src/state/authState.tsx
@@ -55,20 +55,18 @@ export const useSearchState = () => {
 // 팀 생성창
 export const teamNameState = atom({
   key: "teamNameState",
-  default: () => {
-    // 로컬 스토리지에서 팀 이름 가져오기
+  default: (() => {
     const storedTeamName = localStorage.getItem("teamName");
     return storedTeamName || "";
-  },
+  })(),
 });
 
 export const selectedTeamSizeState = atom({
   key: "selectedTeamSizeState",
-  default: () => {
-    // 로컬 스토리지에서 선택된 팀 크기 가져오기
+  default: (() => {
     const storedTeamSize = localStorage.getItem("selectedTeamSize");
     return storedTeamSize || "1-9";
-  },
+  })(),
 });
 
 export interface Team {

--- a/frontend/src/styles/TeamInfoStyled.tsx
+++ b/frontend/src/styles/TeamInfoStyled.tsx
@@ -1,0 +1,62 @@
+import styled from "styled-components";
+
+export const StyledContainer = styled.div`
+  color: #333333;
+  padding: 20px;
+  width: 25%;
+  margin: auto;
+`;
+
+export const StyledFormItem = styled.div`
+  margin: 5px 0;
+
+  label {
+    margin-right: 20px;
+    font-weight: bold;
+  }
+
+  input,
+  select,
+  button {
+    flex: 2;
+    padding: 8px;
+    outline: none;
+  }
+
+  input,
+  select {
+    border: 1px solid #333333;
+    border-radius: 4px;
+  }
+
+  button {
+    flex: 1;
+    margin-left: 10px;
+    background-color: #a3cca3;
+    color: #333333;
+    cursor: pointer;
+
+    &:hover {
+      background-color: #cccccc;
+    }
+  }
+`;
+
+export const StyledImagePreview = styled.div`
+  img {
+    max-width: 100px;
+    max-height: 100px;
+    margin-top: 10px;
+  }
+`;
+
+export const StyledErrorMessage = styled.div`
+  color: red;
+  margin-top: 5px;
+`;
+
+export const StyledHeading = styled.h2`
+  font-size: 24px;
+  font-weight: bold;
+  margin-bottom: 10px;
+`;


### PR DESCRIPTION
### 변경 내용
AS-IS
- 프로필 단일 페이지 
- 팀 생성 페이지 요구충족 미달 시 팀 생성 가능

TO-BE
- 팀 프로필, 팀 내 마이 프로필로 세분화
- 마이페이지에 로그인된 팀원 이름 추가
- 프로필 페이지, 팀생성 페이지 스타일 구현
- 이미지 업로드 구현
- 팀 생성 페이지 요구충족 미달 시 오류 문구 출력

### 테스트
* [ ] 테스트 코드
* [ ] API 테스트

### 관련 이슈

### 변경 사항 검토
* [ ] api 문서 업데이트

### 특이 사항

### 스크린샷 (선택 사항)
