### PR TITLE
Feat/view docs by period

### DIFF
--- a/backend/src/main/java/com/api/backend/documents/controller/DocumentsController.java
+++ b/backend/src/main/java/com/api/backend/documents/controller/DocumentsController.java
@@ -13,11 +13,13 @@ import io.swagger.annotations.ApiResponse;
 import io.swagger.annotations.ApiResponses;
 import io.swagger.v3.oas.annotations.media.Schema;
 import java.security.Principal;
+import java.time.LocalDate;
 import javax.validation.Valid;
 import javax.validation.constraints.Positive;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -25,6 +27,7 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 import springfox.documentation.annotations.ApiIgnore;
 
@@ -66,8 +69,10 @@ public class DocumentsController {
         Long teamId,
         @ApiIgnore
         Principal principal,
-        Pageable pageable) {
-    Page<Documents> docsPage = documentService.getDocsList(teamId, principal, pageable);
+        Pageable pageable,
+      @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate startDt,
+      @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate endDt) {
+    Page<Documents> docsPage = documentService.getDocsList(teamId, principal, pageable, startDt, endDt);
     Page<DocumentResponse> documentDtoPage = docsPage.map(
         document -> DocumentResponse.from(document));
 

--- a/backend/src/main/java/com/api/backend/documents/data/repository/DocumentsRepository.java
+++ b/backend/src/main/java/com/api/backend/documents/data/repository/DocumentsRepository.java
@@ -1,6 +1,7 @@
 package com.api.backend.documents.data.repository;
 
 import com.api.backend.documents.data.entity.Documents;
+import java.time.LocalDateTime;
 import java.util.Optional;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -17,4 +18,11 @@ public interface DocumentsRepository extends MongoRepository<Documents, String> 
   @Transactional
   void deleteById(String documentId);
 
+  Page<Documents> findAllByTeamId(Long teamId, Pageable pageable);
+
+  Page<Documents> findAllByTeamIdAndCreatedDtGreaterThanEqual(Long teamId, LocalDateTime startDt, Pageable pageable);
+
+  Page<Documents> findAllByTeamIdAndCreatedDtLessThanEqual(Long teamId, LocalDateTime endDt, Pageable pageable);
+
+  Page<Documents> findAllByTeamIdAndCreatedDtBetween(Long teamId, LocalDateTime startDt, LocalDateTime endDt, Pageable pageable);
 }

--- a/backend/src/main/java/com/api/backend/documents/service/DocumentService.java
+++ b/backend/src/main/java/com/api/backend/documents/service/DocumentService.java
@@ -1,12 +1,5 @@
 package com.api.backend.documents.service;
 
-import static com.api.backend.global.exception.type.ErrorCode.DOCUMENT_NOT_FOUND_EXCEPTION;
-import static com.api.backend.global.exception.type.ErrorCode.DOCUMENT_NOT_IN_TEAM_EXCEPTION;
-import static com.api.backend.global.exception.type.ErrorCode.DOCUMENT_WRITER_UNMATCH_TEAM_PARTICIPANTS_EXCEPTION;
-import static com.api.backend.global.exception.type.ErrorCode.PRINCIPAL_IS_NULL;
-import static com.api.backend.global.exception.type.ErrorCode.TEAM_PARTICIPANTS_NOT_FOUND_EXCEPTION;
-import static com.api.backend.global.exception.type.ErrorCode.TEAM_PARTICIPANTS_NOT_VALID_EXCEPTION;
-
 import com.api.backend.documents.data.dto.DeleteDocsResponse;
 import com.api.backend.documents.data.dto.DocumentInitRequest;
 import com.api.backend.documents.data.entity.Documents;
@@ -14,9 +7,9 @@ import com.api.backend.documents.data.repository.DocumentsRepository;
 import com.api.backend.documents.valid.DocumentAndCommentValidCheck;
 import com.api.backend.global.exception.CustomException;
 import com.api.backend.team.data.entity.TeamParticipants;
-import com.api.backend.team.data.repository.TeamParticipantsRepository;
 import java.security.Principal;
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
@@ -29,7 +22,6 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 public class DocumentService {
   private final DocumentsRepository documentsRepository;
-  private final TeamParticipantsRepository teamParticipantsRepository;
   private final DocumentAndCommentValidCheck validCheck;
 
   public Page<Documents> getDocsList(Long teamId, Principal principal, Pageable pageable, LocalDate startDt, LocalDate endDt) {
@@ -41,39 +33,20 @@ public class DocumentService {
 
     Page<Documents> allDocsInTeam = null ;
     if (startDt == null && endDt == null) {
-      allDocsInTeam = documentsRepository.findAllByTeamId(teamId, pageable);
-      if (allDocsInTeam != null) {
-        return allDocsInTeam;
-      } else {
-        return Page.empty();
-      }
+      return findAllDocumentInTeam(teamId, pageable, allDocsInTeam);
     }
 
     if (startDt != null && endDt == null) {
-      allDocsInTeam = documentsRepository.findAllByTeamIdAndCreatedDtGreaterThanEqual(teamId, startDt.atStartOfDay() ,pageable);
-      if (allDocsInTeam != null) {
-        return allDocsInTeam;
-      } else {
-        return Page.empty();
-      }
+      return findAllDocumentInTeamWithStartDt(teamId, startDt.atStartOfDay(), pageable, allDocsInTeam);
     }
 
     if (startDt == null && endDt != null) {
-      allDocsInTeam = documentsRepository.findAllByTeamIdAndCreatedDtLessThanEqual(teamId, endDt.plusDays(1).atStartOfDay(), pageable);
-      if (allDocsInTeam != null) {
-        return allDocsInTeam;
-      } else {
-        return Page.empty();
-      }
+      return findAllDocumentInTeamWithEndDt(teamId, endDt.plusDays(1).atStartOfDay(), pageable, allDocsInTeam);
     }
 
     if (startDt != null && endDt != null) {
-      allDocsInTeam = documentsRepository.findAllByTeamIdAndCreatedDtBetween(teamId, startDt.atStartOfDay(), endDt.plusDays(1).atStartOfDay(), pageable);
-      if (allDocsInTeam != null) {
-        return allDocsInTeam;
-      } else {
-        return Page.empty();
-      }
+      return findAllDocumentInTeamBetweenStartDtAndEndDt(teamId, startDt.atStartOfDay(),
+          endDt.plusDays(1).atStartOfDay(), pageable, allDocsInTeam);
     }
     return Page.empty();
   }
@@ -112,5 +85,38 @@ public class DocumentService {
         .message("삭제 되었습니다.")
         .build();
   }
+  private Page<Documents> findAllDocumentInTeam(Long teamId, Pageable pageable, Page<Documents> allDocsInTeam) {
+    allDocsInTeam = documentsRepository.findAllByTeamId(teamId, pageable);
+    if (allDocsInTeam != null) {
+      return allDocsInTeam;
+    } else {
+      return Page.empty();
+    }
+  }
 
+  private Page<Documents> findAllDocumentInTeamWithStartDt(Long teamId, LocalDateTime startDt, Pageable pageable, Page<Documents> allDocsInTeam) {
+    allDocsInTeam = documentsRepository.findAllByTeamIdAndCreatedDtGreaterThanEqual(teamId, startDt ,pageable);
+    if (allDocsInTeam != null) {
+      return allDocsInTeam;
+    } else {
+      return Page.empty();
+    }
+  }
+  private Page<Documents> findAllDocumentInTeamWithEndDt(Long teamId, LocalDateTime endDt, Pageable pageable, Page<Documents> allDocsInTeam) {
+    allDocsInTeam = documentsRepository.findAllByTeamIdAndCreatedDtLessThanEqual(teamId, endDt, pageable);
+    if (allDocsInTeam != null) {
+      return allDocsInTeam;
+    } else {
+      return Page.empty();
+    }
+  }
+
+  private Page<Documents> findAllDocumentInTeamBetweenStartDtAndEndDt(Long teamId, LocalDateTime startDt, LocalDateTime endDt, Pageable pageable, Page<Documents> allDocsInTeam) {
+    allDocsInTeam = documentsRepository.findAllByTeamIdAndCreatedDtBetween(teamId, startDt, endDt, pageable);
+    if (allDocsInTeam != null) {
+      return allDocsInTeam;
+    } else {
+      return Page.empty();
+    }
+  }
 }

--- a/backend/src/main/java/com/api/backend/global/security/jwt/JwtTokenProvider.java
+++ b/backend/src/main/java/com/api/backend/global/security/jwt/JwtTokenProvider.java
@@ -95,7 +95,7 @@ public class JwtTokenProvider {
                         .collect(Collectors.toList());
 
 
-        UserDetails principal = new User(claims.getSubject(), "", authorities);
+        UserDetails principal = new User(claims.get("memberId").toString(), "", authorities);
         return new UsernamePasswordAuthenticationToken(principal, "", authorities);
     }
 

--- a/backend/src/test/java/com/api/backend/comment/service/CommentServiceTest.java
+++ b/backend/src/test/java/com/api/backend/comment/service/CommentServiceTest.java
@@ -19,6 +19,7 @@ import com.api.backend.team.data.repository.TeamParticipantsRepository;
 import java.security.Principal;
 import java.util.Collections;
 import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -47,19 +48,10 @@ class CommentServiceTest {
   @InjectMocks
   private CommentService commentService;
 
-  private Documents createDocuments() {
-    return Documents.builder()
-        .documentIdx("testDocumentIdx")
-        .teamId(1L)
-        .build();
-  }
-  private Comment createComment() {
-    return Comment.builder()
-        .id("commentId")
-        .writerId(23L)
-        .content("아하 이런 회의를 했었군요.")
-        .teamId(1L)
-        .build();
+  private Principal principal;
+  @BeforeEach()
+  private void setUp() {
+    principal = Mockito.mock(Principal.class);
   }
 
   @Test
@@ -75,11 +67,11 @@ class CommentServiceTest {
         .content("아하 이런 회의를 했었군요.")
         .build();
 
-    when(documentsRepository.findByDocumentIdx("testDocumentIdx")).thenReturn(Optional.of(documents));
+    when(documentsRepository.findById("testDocumentId")).thenReturn(Optional.of(documents));
     when(commentRepository.save(any(Comment.class))).thenReturn(comment);
 
     //when
-    Comment savedComment = commentService.createComment(1L, "testDocumentIdx", commentInitRequest);
+    Comment savedComment = commentService.createComment(1L, "testDocumentIdx", commentInitRequest, principal);
 
     //then
     assertNotNull(savedComment);
@@ -95,10 +87,10 @@ class CommentServiceTest {
     //given
     Documents documents =createDocuments();
 
-    when(documentsRepository.findByDocumentIdx("testDocumentIdx")).thenReturn(Optional.of(documents));
+    when(documentsRepository.findById("testDocumentId")).thenReturn(Optional.of(documents));
     //when
     Pageable pageable = PageRequest.of(0, 4, Sort.unsorted());
-    Page<Comment> commentPage = commentService.getCommentList(1L, "testDocumentIdx", pageable);
+    Page<Comment> commentPage = commentService.getCommentList(1L, "testDocumentIdx", principal, pageable);
 
     //then
     assertNotNull(commentPage);
@@ -111,16 +103,16 @@ class CommentServiceTest {
     //given
     Comment comment = createComment();
     Documents documents = Documents.builder()
-        .documentIdx("testDocumentIdx")
+        .id("testDocumentId")
         .teamId(1L)
         .commentIds(Collections.singletonList(comment))
         .build();
 
-    when(documentsRepository.findByDocumentIdx("testDocumentIdx")).thenReturn(Optional.of(documents));
+    when(documentsRepository.findById("testDocumentId")).thenReturn(Optional.of(documents));
 
     //when
     Pageable pageable = PageRequest.of(0, 4, Sort.unsorted());
-    Page<Comment> commentPage = commentService.getCommentList(1L, "testDocumentIdx", pageable);
+    Page<Comment> commentPage = commentService.getCommentList(1L, "testDocumentIdx",  principal, pageable);
 
     //then
     assertNotNull(commentPage);
@@ -133,7 +125,7 @@ class CommentServiceTest {
     //given
     Comment comment = createComment();
     Documents documents = Documents.builder()
-        .documentIdx("testDocumentIdx")
+        .id("testDocumentId")
         .teamId(1L)
         .commentIds(Collections.singletonList(comment))
         .build();
@@ -150,12 +142,12 @@ class CommentServiceTest {
         .teamId(1L)
         .build();
 
-    when(documentsRepository.findByDocumentIdx("testDocumentIdx")).thenReturn(Optional.of(documents));
+    when(documentsRepository.findById("testDocumentId")).thenReturn(Optional.of(documents));
     when(commentRepository.findById("commentId")).thenReturn(Optional.of(comment));
     when(commentRepository.save(any(Comment.class))).thenReturn(editCommentMock);
     //when
     Comment editComment = commentService.editComment(1L, "testDocumentIdx", "commentId",
-        commentEditRequest);
+        commentEditRequest, principal);
 
     //then
     assertNotNull(editComment);
@@ -173,7 +165,7 @@ class CommentServiceTest {
     //given
     Comment comment = createComment();
     Documents documents = Documents.builder()
-        .documentIdx("testDocumentIdx")
+        .id("testDocumentId")
         .teamId(1L)
         .commentIds(Collections.singletonList(comment))
         .build();
@@ -183,7 +175,7 @@ class CommentServiceTest {
         .build();
     Principal principal = Mockito.mock(Principal.class);
     when(principal.getName()).thenReturn("1");
-    when(documentsRepository.findByDocumentIdx("testDocumentIdx")).thenReturn(Optional.of(documents));
+    when(documentsRepository.findById("testDocumentId")).thenReturn(Optional.of(documents));
     when(commentRepository.findById("commentId")).thenReturn(Optional.of(comment));
     when(teamParticipantsRepository.findByMember_MemberId(1L)).thenReturn(Optional.of(teamParticipants));
     //when
@@ -197,5 +189,20 @@ class CommentServiceTest {
 
     // TODO : 데이터 베이스를 이용한 통합 테스트시 해야할 일
 //    assertEquals(0, documents.getCommentIds().size());
+  }
+
+  private Documents createDocuments() {
+    return Documents.builder()
+        .id("testDocumentId")
+        .teamId(1L)
+        .build();
+  }
+  private Comment createComment() {
+    return Comment.builder()
+        .id("commentId")
+        .writerId(23L)
+        .content("아하 이런 회의를 했었군요.")
+        .teamId(1L)
+        .build();
   }
 }


### PR DESCRIPTION
### 변경 내용
<!-- 여기에 변경한 내용을 명시해주세요. -->

AS-IS
* 팀별로 전체 문서를 조회해야하는데 그냥 전체 findAll로만 구현함.

TO-BE
* 기간별로 문서 조회 가능
* 팀별로 전체 문서 조회 가능

### 테스트
<!-- 본 변경사항이 테스트가 되었는지 기술해주세요 --> 
* [X] 테스트 코드
* [X] API 테스트

### 관련 이슈
<!-- 이 PR과 관련된 이슈 번호를 명시해주세요. 예: #123 -->
#42 

### 변경 사항 검토
* [ ] api 문서 업데이트

### 특이 사항
<!-- 리뷰어에게 특별히 주의해야 할 사항이나 테스트할 때 필요한 추가 정보를 여기에 적어주세요. -->
* 이전 PR 때 테스트 코드를 제대로 add 하지 않아 back 에서 pull 받았을때 테스트코드 실행시 에러가 떴을 텐데 죄송합니다ㅠㅠ 우선 에러 안나게 수정해서 커밋했으나 완벽한 테스트 코드는 다시 작성하진 못했습니다. 추후에 다시 작성할수있을때 작성하겠습니다.
* security 부분 진성님께서 알려주신 부분 빠르게 merge를 위해 제가 커밋했습니다.
* startDt나 endDt는 required=false이며 startDt만 있을때는 생성시간 >= startDt 전체 팀의 문서를 조회,
endDt만 있을때는 생성시간 <= endDt 전체팀의 문서를 조회, startDt, endDt는 그 사이값의 전체 팀의 문서를 조회합니다.

### 스크린샷 (선택 사항)
<!-- 필요한 경우 변경 내용에 대한 스크린샷을 첨부하세요. -->