### PR TITLE
Feat/edit docs by websocket

### DIFF
--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -36,6 +36,11 @@ dependencies {
     // mongoDB
     implementation 'org.springframework.boot:spring-boot-starter-data-mongodb'
 
+    // websocket
+    implementation 'org.springframework.boot:spring-boot-starter-websocket'
+    implementation 'org.webjars:sockjs-client:1.1.2'
+    implementation 'org.webjars:stomp-websocket:2.3.3-1'
+
     // swagger
     implementation 'io.springfox:springfox-boot-starter:3.0.0'
     implementation 'io.springfox:springfox-swagger-ui:3.0.0'

--- a/backend/src/main/java/com/api/backend/documents/controller/DocumentsWebSocketController.java
+++ b/backend/src/main/java/com/api/backend/documents/controller/DocumentsWebSocketController.java
@@ -1,0 +1,31 @@
+package com.api.backend.documents.controller;
+
+import static com.api.backend.global.exception.type.ErrorCode.DOCUMENT_NOT_FOUND_EXCEPTION;
+
+import com.api.backend.documents.data.dto.DocumentMessage;
+import com.api.backend.documents.data.dto.DocumentResponse;
+import com.api.backend.documents.data.entity.Documents;
+import com.api.backend.documents.data.repository.DocumentsRepository;
+import com.api.backend.global.exception.CustomException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.messaging.handler.annotation.MessageMapping;
+import org.springframework.messaging.handler.annotation.Payload;
+import org.springframework.messaging.handler.annotation.SendTo;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+public class DocumentsWebSocketController {
+  private final DocumentsRepository documentsRepository;
+
+  @MessageMapping("/chat.showDocs")
+  @SendTo("/topic/public")
+  public DocumentResponse sendMessage(
+      @Payload DocumentMessage documentMessage
+  ) {
+    Documents documents = documentsRepository.findById(documentMessage.getDocumentId())
+        .orElseThrow(() -> new CustomException(DOCUMENT_NOT_FOUND_EXCEPTION));
+    return DocumentResponse.from(documents);
+  }
+
+}

--- a/backend/src/main/java/com/api/backend/documents/data/dto/DocumentMessage.java
+++ b/backend/src/main/java/com/api/backend/documents/data/dto/DocumentMessage.java
@@ -1,0 +1,16 @@
+package com.api.backend.documents.data.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class DocumentMessage {
+  private String documentId;
+}

--- a/backend/src/main/java/com/api/backend/global/config/CorsConfig.java
+++ b/backend/src/main/java/com/api/backend/global/config/CorsConfig.java
@@ -1,0 +1,29 @@
+package com.api.backend.global.config;
+
+import java.util.Arrays;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
+import org.springframework.web.filter.CorsFilter;
+
+@Configuration
+public class CorsConfig {
+
+  @Value("${frontend.host}")
+  String host;
+  @Value("${frontend.port}")
+  String port;
+
+  @Bean
+  public CorsFilter corsFilter() {
+    UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
+    CorsConfiguration config = new CorsConfiguration();
+    config.setAllowCredentials(true);
+    config.addAllowedOriginPattern("http://" + host + ":" + port);
+    config.addAllowedHeader("*");
+    config.setAllowedMethods(Arrays.asList("GET", "POST", "PUT", "DELETE"));
+    source.registerCorsConfiguration("/**", config);
+    return new CorsFilter(source);
+  }}

--- a/backend/src/main/java/com/api/backend/global/config/WebConfig.java
+++ b/backend/src/main/java/com/api/backend/global/config/WebConfig.java
@@ -35,4 +35,10 @@ public class WebConfig implements WebMvcConfigurer {
     pageableHandlerMethodArgumentResolver.setFallbackPageable(PageRequest.of(0, 10));
     argumentResolvers.add(pageableHandlerMethodArgumentResolver);
   }
+  @Override
+  public void addCorsMappings(CorsRegistry registry) {
+    registry.addMapping("/**")
+        .allowedOrigins("http://" + host + ":" + port)
+        .allowedOriginPatterns("*");
+  }
 }

--- a/backend/src/main/java/com/api/backend/global/config/WebConfig.java
+++ b/backend/src/main/java/com/api/backend/global/config/WebConfig.java
@@ -11,6 +11,7 @@ import org.springframework.data.domain.PageRequest;
 import org.springframework.data.web.PageableHandlerMethodArgumentResolver;
 import org.springframework.data.web.SortHandlerMethodArgumentResolver;
 import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.servlet.config.annotation.CorsRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
 @Configuration
@@ -33,20 +34,5 @@ public class WebConfig implements WebMvcConfigurer {
     pageableHandlerMethodArgumentResolver.setMaxPageSize(500);
     pageableHandlerMethodArgumentResolver.setFallbackPageable(PageRequest.of(0, 10));
     argumentResolvers.add(pageableHandlerMethodArgumentResolver);
-  }
-
-  @Bean
-  public CorsFilter corsFilter() {
-    UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
-    CorsConfiguration config = new CorsConfiguration();
-    config.setAllowCredentials(true);
-    config.addAllowedOriginPattern("http://" + host + ":" + port);
-    config.addAllowedHeader("*");
-    config.addAllowedMethod("GET");
-    config.addAllowedMethod("POST");
-    config.addAllowedMethod("PUT");
-    config.addAllowedMethod("DELETE");
-    source.registerCorsConfiguration("/**", config);
-    return new CorsFilter(source);
   }
 }

--- a/backend/src/main/java/com/api/backend/global/config/WebSocketConfig.java
+++ b/backend/src/main/java/com/api/backend/global/config/WebSocketConfig.java
@@ -1,0 +1,30 @@
+package com.api.backend.global.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.messaging.simp.config.MessageBrokerRegistry;
+import org.springframework.web.socket.config.annotation.EnableWebSocketMessageBroker;
+import org.springframework.web.socket.config.annotation.StompEndpointRegistry;
+import org.springframework.web.socket.config.annotation.WebSocketMessageBrokerConfigurer;
+
+@Configuration
+@EnableWebSocketMessageBroker
+public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
+
+  @Override
+  public void configureMessageBroker(MessageBrokerRegistry config) {
+    config.enableSimpleBroker("/topic");
+    config.setApplicationDestinationPrefixes("/app");
+  }
+
+  @Override
+  public void registerStompEndpoints(StompEndpointRegistry registry) {
+    registry.addEndpoint("/ws")
+        .setAllowedOriginPatterns("*") // 이 부분을 추가하여 CORS를 허용할 수 있습니다.
+        .setAllowedOrigins("http://localhost:5173");
+
+    registry.addEndpoint("/ws")
+        .setAllowedOriginPatterns("*") // 이 부분을 추가하여 CORS를 허용할 수 있습니다.
+        .setAllowedOrigins("http://localhost:5173")
+        .withSockJS(); // SockJS를 사용하고자 하는 경우에만 추가합니다.
+  }
+}

--- a/backend/src/main/java/com/api/backend/notification/controller/NotificationController.java
+++ b/backend/src/main/java/com/api/backend/notification/controller/NotificationController.java
@@ -1,12 +1,11 @@
 package com.api.backend.notification.controller;
 
-import com.api.backend.notification.data.type.NotificationUserType;
+
 import com.api.backend.notification.service.NotificationService;
 import java.security.Principal;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 


### PR DESCRIPTION
### 변경 내용
<!-- 여기에 변경한 내용을 명시해주세요. -->

AS-IS
* 기존 CorsFilter 부분 존재

TO-BE
* CorsConfig 따로 생성해 기존 CorsFilter 부분 이동
* CorsConfig에 메서드를 List로 add함.
* 웹소켓으로 db에 저장되어 있는 문서(문서 id로) 가져옴.

### 테스트
<!-- 본 변경사항이 테스트가 되었는지 기술해주세요 --> 
* [ ] 테스트 코드
* [X] API 테스트 

### 관련 이슈
<!-- 이 PR과 관련된 이슈 번호를 명시해주세요. 예: #123 -->
#90 

### 변경 사항 검토
* [ ] api 문서 업데이트

### 특이 사항
<!-- 리뷰어에게 특별히 주의해야 할 사항이나 테스트할 때 필요한 추가 정보를 여기에 적어주세요. -->
* NotificationController 부분에서 에러를 유발하는 import 부분을 지웠습니다.(진영님과 소통했습니다.)
* API 테스트는 이전에 클라이언트 부분(useEffect, stompJS, draft.js)를 통해 확인했으나 현재 프론트단에서 라이브러리 변경 이슈로 다시 확인해야하는 부분입니다. 이렇게 문서 상세 조회시 웹소켓 소통을 시작해 db에서 문서를 가져옵니다.

### 스크린샷 (선택 사항)
<!-- 필요한 경우 변경 내용에 대한 스크린샷을 첨부하세요. -->
![image](https://github.com/100backfro/teammate/assets/94779505/780db955-43ac-4a0a-9b6a-d535d54b0b32)
이전의 확인했던 캡쳐본 입니다. 별도로 만들어뒀던 documentIdx로 조회했으나 현재는 기본 인덱스인 id로 조회로 수정했습니다.

현재 quill.js로 불러오는것 확인했습니다.
![image](https://github.com/100backfro/teammate/assets/94779505/69692f19-7d18-431c-a700-80f4d9b78875)

-> 도헌님 캡쳐본, 해당 캡쳐에서 save는 무시하셔도 됩니다.
