### PR TITLE
Refactor/calendar schedule

### DIFF
--- a/backend/src/main/java/com/api/backend/notification/data/dto/NotificationsResponse.java
+++ b/backend/src/main/java/com/api/backend/notification/data/dto/NotificationsResponse.java
@@ -2,7 +2,6 @@ package com.api.backend.notification.data.dto;
 
 import com.api.backend.notification.data.entity.Notification;
 import com.api.backend.notification.data.type.AlarmType;
-import com.api.backend.notification.data.type.Type;
 import java.time.LocalDateTime;
 import lombok.AllArgsConstructor;
 import lombok.Builder;

--- a/backend/src/main/java/com/api/backend/notification/service/NotificationService.java
+++ b/backend/src/main/java/com/api/backend/notification/service/NotificationService.java
@@ -15,6 +15,7 @@ import com.api.backend.team.service.TeamService;
 import java.util.List;
 import java.util.Objects;
 import lombok.RequiredArgsConstructor;
+import org.hibernate.Hibernate;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;

--- a/backend/src/main/java/com/api/backend/schedule/controller/ScheduleController.java
+++ b/backend/src/main/java/com/api/backend/schedule/controller/ScheduleController.java
@@ -3,10 +3,12 @@ package com.api.backend.schedule.controller;
 import com.api.backend.category.type.CategoryType;
 import com.api.backend.schedule.data.dto.AllSchedulesMonthlyView;
 import com.api.backend.schedule.data.dto.RepeatScheduleInfoEditRequest;
+import com.api.backend.schedule.data.dto.RepeatScheduleResponse;
 import com.api.backend.schedule.data.dto.ScheduleEditResponse;
 import com.api.backend.schedule.data.dto.ScheduleRequest;
 import com.api.backend.schedule.data.dto.ScheduleResponse;
 import com.api.backend.schedule.data.dto.SimpleScheduleInfoEditRequest;
+import com.api.backend.schedule.data.dto.SimpleScheduleResponse;
 import com.api.backend.schedule.service.ScheduleService;
 import java.time.LocalDateTime;
 import javax.validation.Valid;
@@ -48,11 +50,20 @@ public class ScheduleController {
     return ResponseEntity.ok(scheduleResponse);
   }
 
-  @GetMapping("/{scheduleId}")
-  public ResponseEntity<ScheduleResponse> searchScheduleDetailInfo(@PathVariable Long teamId,
+  @GetMapping("/repeat/{scheduleId}")
+  public ResponseEntity<RepeatScheduleResponse> getRepeatScheduleDetailInfo(@PathVariable Long teamId,
       @PathVariable Long scheduleId) {
-    ScheduleResponse response = ScheduleResponse.from(
-        scheduleService.searchScheduleDetailInfo(scheduleId, teamId)
+    RepeatScheduleResponse response = RepeatScheduleResponse.from(
+        scheduleService.getRepeatScheduleDetailInfo(scheduleId, teamId)
+    );
+    return ResponseEntity.ok(response);
+  }
+
+  @GetMapping("/simple/{scheduleId}")
+  public ResponseEntity<SimpleScheduleResponse> getSimpleScheduleDetailInfo(@PathVariable Long teamId,
+      @PathVariable Long scheduleId) {
+    SimpleScheduleResponse response = SimpleScheduleResponse.from(
+        scheduleService.getSimpleScheduleDetailInfo(scheduleId, teamId)
     );
     return ResponseEntity.ok(response);
   }

--- a/backend/src/main/java/com/api/backend/schedule/controller/ScheduleController.java
+++ b/backend/src/main/java/com/api/backend/schedule/controller/ScheduleController.java
@@ -38,14 +38,12 @@ public class ScheduleController {
   public ResponseEntity<ScheduleResponse> addSchedule(@RequestBody @Valid ScheduleRequest request,
       @PathVariable Long teamId) {
     ScheduleResponse scheduleResponse;
-    if (!request.isRepeat()) {
-      scheduleResponse = ScheduleResponse.from(
-          scheduleService.addSimpleScheduleAndSave(request)
-      );
+    if (request.getRepeatCycle() != null) {
+      RepeatScheduleResponse response = RepeatScheduleResponse.from(scheduleService.addRepeatScheduleAndSave(request));
+      scheduleResponse = ScheduleResponse.from(response);
     } else {
-      scheduleResponse = ScheduleResponse.from(
-          scheduleService.addRepeatScheduleAndSave(request)
-      );
+      SimpleScheduleResponse response = SimpleScheduleResponse.from(scheduleService.addSimpleScheduleAndSave(request));
+      scheduleResponse = ScheduleResponse.from(response);
     }
     return ResponseEntity.ok(scheduleResponse);
   }

--- a/backend/src/main/java/com/api/backend/schedule/controller/ScheduleController.java
+++ b/backend/src/main/java/com/api/backend/schedule/controller/ScheduleController.java
@@ -10,6 +10,13 @@ import com.api.backend.schedule.data.dto.ScheduleResponse;
 import com.api.backend.schedule.data.dto.SimpleScheduleInfoEditRequest;
 import com.api.backend.schedule.data.dto.SimpleScheduleResponse;
 import com.api.backend.schedule.service.ScheduleService;
+import io.swagger.annotations.Api;
+import io.swagger.annotations.ApiImplicitParam;
+import io.swagger.annotations.ApiImplicitParams;
+import io.swagger.annotations.ApiOperation;
+import io.swagger.annotations.ApiResponse;
+import io.swagger.annotations.ApiResponses;
+import java.security.Principal;
 import java.time.LocalDateTime;
 import javax.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -26,53 +33,176 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
+import springfox.documentation.annotations.ApiIgnore;
 
 @RestController
+@Api(tags = "일정")
 @RequiredArgsConstructor
 @RequestMapping("/team/{teamId}/schedules")
 public class ScheduleController {
 
   private final ScheduleService scheduleService;
 
+  @ApiOperation(value = "일정 생성")
+  @ApiResponses(value = {
+      @ApiResponse(code = 200, message = "일정이 성공적으로 추가되었습니다."),
+      @ApiResponse(code = 404, message = "페이지를 찾을 수 없습니다."),
+      @ApiResponse(code = 400, message = "일정 추가에 실패했습니다.")
+  })
+  @ApiImplicitParams(
+      {
+          @ApiImplicitParam(
+              name = "access token"
+              , value = "jwt access token"
+              , required = true
+              , dataType = "String"
+              , paramType = "header"
+              , defaultValue = "None"),
+          @ApiImplicitParam(
+              name = "teamId"
+              , value = "팀 id"
+              , required = true
+              , dataType = "Long"
+              , paramType = "path"
+              , defaultValue = "None"
+              , example = "1")
+      })
   @PostMapping
   public ResponseEntity<ScheduleResponse> addSchedule(@RequestBody @Valid ScheduleRequest request,
-      @PathVariable Long teamId) {
+      @PathVariable Long teamId, @ApiIgnore Principal principal) {
     ScheduleResponse scheduleResponse;
     if (request.getRepeatCycle() != null) {
-      RepeatScheduleResponse response = RepeatScheduleResponse.from(scheduleService.addRepeatScheduleAndSave(request));
+      RepeatScheduleResponse response = RepeatScheduleResponse.from(
+          scheduleService.addRepeatScheduleAndSave(request, principal)
+      );
       scheduleResponse = ScheduleResponse.from(response);
     } else {
-      SimpleScheduleResponse response = SimpleScheduleResponse.from(scheduleService.addSimpleScheduleAndSave(request));
+      SimpleScheduleResponse response = SimpleScheduleResponse.from(
+          scheduleService.addSimpleScheduleAndSave(request, principal)
+      );
       scheduleResponse = ScheduleResponse.from(response);
     }
     return ResponseEntity.ok(scheduleResponse);
   }
 
+
+  @ApiOperation(value = "반복일정 상세 정보 조회")
+  @ApiResponses(value = {
+      @ApiResponse(code = 200, message = "반복일정 상세 정보 조회에 성공하였습니다."),
+      @ApiResponse(code = 404, message = "페이지를 찾을 수 없습니다."),
+      @ApiResponse(code = 400, message = "반복일정 조회에 실패했습니다.")
+  })
+  @ApiImplicitParams(
+      {
+          @ApiImplicitParam(
+              name = "access token"
+              , value = "jwt access token"
+              , required = true
+              , dataType = "String"
+              , paramType = "header"
+              , defaultValue = "None"),
+          @ApiImplicitParam(
+              name = "teamId"
+              , value = "팀 id"
+              , required = true
+              , dataType = "Long"
+              , paramType = "path"
+              , defaultValue = "None"
+              , example = "1"),
+          @ApiImplicitParam(
+              name = "scheduleId"
+              , value = "반복일정 id"
+              , required = true
+              , dataType = "Long"
+              , paramType = "path"
+              , defaultValue = "None"
+              , example = "1")
+      })
   @GetMapping("/repeat/{scheduleId}")
-  public ResponseEntity<RepeatScheduleResponse> getRepeatScheduleDetailInfo(@PathVariable Long teamId,
-      @PathVariable Long scheduleId) {
+  public ResponseEntity<RepeatScheduleResponse> getRepeatScheduleDetailInfo(
+      @PathVariable Long teamId,
+      @PathVariable Long scheduleId, @ApiIgnore Principal principal) {
     RepeatScheduleResponse response = RepeatScheduleResponse.from(
-        scheduleService.getRepeatScheduleDetailInfo(scheduleId, teamId)
+        scheduleService.getRepeatScheduleDetailInfo(scheduleId, teamId, principal)
     );
     return ResponseEntity.ok(response);
   }
 
+
+  @ApiOperation(value = "단순일정 상세 정보 조회")
+  @ApiResponses(value = {
+      @ApiResponse(code = 200, message = "단순일정 상세 정보 조회에 성공하였습니다."),
+      @ApiResponse(code = 404, message = "페이지를 찾을 수 없습니다."),
+      @ApiResponse(code = 400, message = "단순일정 조회에 실패했습니다.")
+  })
+  @ApiImplicitParams(
+      {
+          @ApiImplicitParam(
+              name = "access token"
+              , value = "jwt access token"
+              , required = true
+              , dataType = "String"
+              , paramType = "header"
+              , defaultValue = "None"),
+          @ApiImplicitParam(
+              name = "teamId"
+              , value = "팀 id"
+              , required = true
+              , dataType = "Long"
+              , paramType = "path"
+              , defaultValue = "None"
+              , example = "1"),
+          @ApiImplicitParam(
+              name = "scheduleId"
+              , value = "단순일정 id"
+              , required = true
+              , dataType = "Long"
+              , paramType = "path"
+              , defaultValue = "None"
+              , example = "1")
+      })
   @GetMapping("/simple/{scheduleId}")
-  public ResponseEntity<SimpleScheduleResponse> getSimpleScheduleDetailInfo(@PathVariable Long teamId,
-      @PathVariable Long scheduleId) {
+  public ResponseEntity<SimpleScheduleResponse> getSimpleScheduleDetailInfo(
+      @PathVariable Long teamId,
+      @PathVariable Long scheduleId, @ApiIgnore Principal principal) {
     SimpleScheduleResponse response = SimpleScheduleResponse.from(
-        scheduleService.getSimpleScheduleDetailInfo(scheduleId, teamId)
+        scheduleService.getSimpleScheduleDetailInfo(scheduleId, teamId, principal)
     );
     return ResponseEntity.ok(response);
   }
 
 
+  @ApiOperation(value = "캘린더 월간보기")
+  @ApiResponses(value = {
+      @ApiResponse(code = 200, message = "월간보기 조회에 성공하였습니다."),
+      @ApiResponse(code = 404, message = "페이지를 찾을 수 없습니다."),
+      @ApiResponse(code = 400, message = "월간보기 조회에 실패했습니다.")
+  })
+  @ApiImplicitParams(
+      {
+          @ApiImplicitParam(
+              name = "access token"
+              , value = "jwt access token"
+              , required = true
+              , dataType = "String"
+              , paramType = "header"
+              , defaultValue = "None"),
+          @ApiImplicitParam(
+              name = "teamId"
+              , value = "팀 id"
+              , required = true
+              , dataType = "Long"
+              , paramType = "path"
+              , defaultValue = "None"
+              , example = "1")
+      })
   @GetMapping("/calendar")
   public ResponseEntity<Page<AllSchedulesMonthlyView>> getMonthlySchedules(
       @PathVariable Long teamId,
       @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) LocalDateTime startDt,
       @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) LocalDateTime endDt,
       @RequestParam(required = false) String categoryType,
+      @ApiIgnore Principal principal,
       Pageable pageable
   ) {
     if (startDt == null) {
@@ -84,45 +214,171 @@ public class ScheduleController {
 
     Page<AllSchedulesMonthlyView> allSchedules;
     if (categoryType == null) {
-      allSchedules = scheduleService.getAllMonthlySchedules(teamId, pageable);
+      allSchedules = scheduleService.getAllMonthlySchedules(teamId, pageable, principal);
     } else {
       CategoryType enumCategoryType = CategoryType.valueOf(categoryType.toUpperCase());
-      allSchedules = scheduleService.getCategoryTypeMonthlySchedules(teamId, enumCategoryType, pageable);
+      allSchedules = scheduleService.getCategoryTypeMonthlySchedules(teamId, enumCategoryType,
+          pageable, principal);
     }
 
     return ResponseEntity.ok(allSchedules);
   }
 
-
+  @ApiOperation(value = "단순일정 수정")
+  @ApiResponses(value = {
+      @ApiResponse(code = 200, message = "일정이 성공적으로 수정되었습니다."),
+      @ApiResponse(code = 404, message = "페이지를 찾을 수 없습니다."),
+      @ApiResponse(code = 400, message = "일정 수정에 실패했습니다.")
+  })
+  @ApiImplicitParams(
+      {
+          @ApiImplicitParam(
+              name = "access token"
+              , value = "jwt access token"
+              , required = true
+              , dataType = "String"
+              , paramType = "header"
+              , defaultValue = "None"),
+          @ApiImplicitParam(
+              name = "teamId"
+              , value = "팀 id"
+              , required = true
+              , dataType = "Long"
+              , paramType = "path"
+              , defaultValue = "None"
+              , example = "1")
+      })
   @PutMapping("/simple")
-  public ResponseEntity<ScheduleEditResponse> editSimpleSchedule(@PathVariable Long teamId,
-      @RequestBody
-      @Valid SimpleScheduleInfoEditRequest editRequest) {
+  public ResponseEntity<ScheduleEditResponse> editSimpleSchedule(
+      @PathVariable Long teamId,
+      @RequestBody @Valid SimpleScheduleInfoEditRequest editRequest,
+      @ApiIgnore Principal principal
+  ) {
     ScheduleEditResponse response = ScheduleEditResponse.from(
-        scheduleService.editSimpleScheduleInfoAndSave(editRequest));
+        scheduleService.editSimpleScheduleInfoAndSave(editRequest, principal)
+    );
     return ResponseEntity.ok(response);
   }
 
+
+  @ApiOperation(value = "반복일정 수정")
+  @ApiResponses(value = {
+      @ApiResponse(code = 200, message = "일정이 성공적으로 수정되었습니다."),
+      @ApiResponse(code = 404, message = "페이지를 찾을 수 없습니다."),
+      @ApiResponse(code = 400, message = "일정 수정에 실패했습니다.")
+  })
+  @ApiImplicitParams(
+      {
+          @ApiImplicitParam(
+              name = "access token"
+              , value = "jwt access token"
+              , required = true
+              , dataType = "String"
+              , paramType = "header"
+              , defaultValue = "None"),
+          @ApiImplicitParam(
+              name = "teamId"
+              , value = "팀 id"
+              , required = true
+              , dataType = "Long"
+              , paramType = "path"
+              , defaultValue = "None"
+              , example = "1")
+      })
   @PutMapping("/repeat")
-  public ResponseEntity<ScheduleEditResponse> editRepeatSchedule(@PathVariable Long teamId,
-      @RequestBody
-      @Valid RepeatScheduleInfoEditRequest editRequest) {
+  public ResponseEntity<ScheduleEditResponse> editRepeatSchedule(
+      @PathVariable Long teamId,
+      @RequestBody @Valid RepeatScheduleInfoEditRequest editRequest,
+      @ApiIgnore Principal principal
+  ) {
     ScheduleEditResponse response = ScheduleEditResponse.from(
-        scheduleService.editRepeatScheduleInfoAndSave(editRequest));
+        scheduleService.editRepeatScheduleInfoAndSave(editRequest, principal));
     return ResponseEntity.ok(response);
   }
 
+
+  @ApiOperation(value = "단순일정 삭제")
+  @ApiResponses(value = {
+      @ApiResponse(code = 200, message = "일정이 성공적으로 삭제되었습니다."),
+      @ApiResponse(code = 404, message = "페이지를 찾을 수 없습니다."),
+      @ApiResponse(code = 400, message = "일정 삭제에 실패했습니다.")
+  })
+  @ApiImplicitParams(
+      {
+          @ApiImplicitParam(
+              name = "access token"
+              , value = "jwt access token"
+              , required = true
+              , dataType = "String"
+              , paramType = "header"
+              , defaultValue = "None"),
+          @ApiImplicitParam(
+              name = "teamId"
+              , value = "팀 id"
+              , required = true
+              , dataType = "Long"
+              , paramType = "path"
+              , defaultValue = "None"
+              , example = "1"),
+          @ApiImplicitParam(
+              name = "scheduleId"
+              , value = "단순일정 id"
+              , required = true
+              , dataType = "Long"
+              , paramType = "path"
+              , defaultValue = "None"
+              , example = "1")
+      })
   @DeleteMapping("/simple/{scheduleId}")
-  public ResponseEntity<String> deleteSimpleSchedule(@PathVariable Long teamId,
-      @PathVariable Long scheduleId) {
-    scheduleService.deleteSimpleSchedule(scheduleId);
+  public ResponseEntity<String> deleteSimpleSchedule(
+      @PathVariable Long teamId,
+      @PathVariable Long scheduleId,
+      @ApiIgnore Principal principal
+  ) {
+    scheduleService.deleteSimpleSchedule(scheduleId, principal);
     return ResponseEntity.ok("해당 단순 일정이 정상적으로 삭제되었습니다.");
   }
 
+
+  @ApiOperation(value = "반복일정 삭제")
+  @ApiResponses(value = {
+      @ApiResponse(code = 200, message = "일정이 성공적으로 삭제되었습니다."),
+      @ApiResponse(code = 404, message = "페이지를 찾을 수 없습니다."),
+      @ApiResponse(code = 400, message = "일정 삭제에 실패했습니다.")
+  })
+  @ApiImplicitParams(
+      {
+          @ApiImplicitParam(
+              name = "access token"
+              , value = "jwt access token"
+              , required = true
+              , dataType = "String"
+              , paramType = "header"
+              , defaultValue = "None"),
+          @ApiImplicitParam(
+              name = "teamId"
+              , value = "팀 id"
+              , required = true
+              , dataType = "Long"
+              , paramType = "path"
+              , defaultValue = "None"
+              , example = "1"),
+          @ApiImplicitParam(
+              name = "scheduleId"
+              , value = "반복일정 id"
+              , required = true
+              , dataType = "Long"
+              , paramType = "path"
+              , defaultValue = "None"
+              , example = "1")
+      })
   @DeleteMapping("/repeat/{scheduleId}")
-  public ResponseEntity<String> deleteSchedule(@PathVariable Long teamId,
-      @PathVariable Long scheduleId) {
-    scheduleService.deleteRepeatSchedule(scheduleId);
+  public ResponseEntity<String> deleteSchedule(
+      @PathVariable Long teamId,
+      @PathVariable Long scheduleId,
+      @ApiIgnore Principal principal
+  ) {
+    scheduleService.deleteRepeatSchedule(scheduleId, principal);
     return ResponseEntity.ok("해당 반복 일정이 정상적으로 삭제되었습니다.");
   }
 }

--- a/backend/src/main/java/com/api/backend/schedule/data/dto/AllSchedulesMonthlyView.java
+++ b/backend/src/main/java/com/api/backend/schedule/data/dto/AllSchedulesMonthlyView.java
@@ -1,0 +1,65 @@
+package com.api.backend.schedule.data.dto;
+
+import com.api.backend.category.data.entity.ScheduleCategory;
+import com.api.backend.category.type.CategoryType;
+import com.api.backend.schedule.data.entity.RepeatSchedule;
+import com.api.backend.schedule.data.entity.SimpleSchedule;
+import com.fasterxml.jackson.annotation.JsonFormat;
+import java.time.LocalDateTime;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import org.springframework.data.domain.Page;
+
+@Getter
+@AllArgsConstructor
+@Builder
+public class AllSchedulesMonthlyView {
+  private Long scheduleId;
+  private CategoryType category;
+  private String title;
+  private String content;
+  private String place;
+  @JsonFormat(pattern = "yyyy-MM-dd HH:mm")
+  private LocalDateTime startDt;
+  @JsonFormat(pattern = "yyyy-MM-dd HH:mm")
+  private LocalDateTime endDt;
+  private String color;
+  private String scheduleType;
+
+  public static AllSchedulesMonthlyView from(RepeatSchedule repeatSchedule) {
+    return AllSchedulesMonthlyView.builder()
+        .scheduleId(repeatSchedule.getRepeatScheduleId())
+        .category(repeatSchedule.getScheduleCategory().getCategoryType())
+        .title(repeatSchedule.getTitle())
+        .content(repeatSchedule.getContent())
+        .place(repeatSchedule.getPlace())
+        .startDt(repeatSchedule.getStartDt())
+        .endDt(repeatSchedule.getEndDt())
+        .color(repeatSchedule.getColor())
+        .scheduleType("반복일정")
+        .build();
+  }
+
+  public static AllSchedulesMonthlyView from(SimpleSchedule simpleSchedule) {
+    return AllSchedulesMonthlyView.builder()
+        .scheduleId(simpleSchedule.getSimpleScheduleId())
+        .category(simpleSchedule.getScheduleCategory().getCategoryType())
+        .title(simpleSchedule.getTitle())
+        .content(simpleSchedule.getContent())
+        .place(simpleSchedule.getPlace())
+        .startDt(simpleSchedule.getStartDt())
+        .endDt(simpleSchedule.getEndDt())
+        .color(simpleSchedule.getColor())
+        .scheduleType("단순일정")
+        .build();
+  }
+
+  public static Page<AllSchedulesMonthlyView> fromSimpleSchedulePage(Page<SimpleSchedule> simpleSchedules) {
+    return simpleSchedules.map(AllSchedulesMonthlyView::from);
+  }
+
+  public static Page<AllSchedulesMonthlyView> fromRepeatSchedulePage(Page<RepeatSchedule> repeatSchedules) {
+    return repeatSchedules.map(AllSchedulesMonthlyView::from);
+  }
+}

--- a/backend/src/main/java/com/api/backend/schedule/data/dto/RepeatScheduleResponse.java
+++ b/backend/src/main/java/com/api/backend/schedule/data/dto/RepeatScheduleResponse.java
@@ -1,0 +1,93 @@
+package com.api.backend.schedule.data.dto;
+
+import com.api.backend.schedule.data.entity.RepeatSchedule;
+import com.api.backend.schedule.data.entity.TeamParticipantsSchedule;
+import com.api.backend.schedule.data.type.RepeatCycle;
+import com.api.backend.team.data.type.TeamRole;
+import com.fasterxml.jackson.annotation.JsonFormat;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+@AllArgsConstructor
+public class RepeatScheduleResponse {
+
+  private String scheduleType;
+  private Long scheduleId;
+  private Long categoryId;
+  @JsonFormat(pattern = "yyyy-MM-dd HH:mm")
+  private LocalDateTime startDt;
+  @JsonFormat(pattern = "yyyy-MM-dd HH:mm")
+  private LocalDateTime endDt;
+  private String title;
+  private String content;
+  private String place;
+  private RepeatCycle repeatCycle;
+  private String month;
+  private int day;
+  private String dayOfWeek;
+  private List<Long> teamParticipantsIds;
+  private List<String> teamParticipantsNames;
+  private List<TeamRole> teamRoles;
+
+  public static RepeatScheduleResponse from(RepeatSchedule repeatSchedule) {
+    return RepeatScheduleResponse.builder()
+        .scheduleType("단순 일정")
+        .scheduleId(repeatSchedule.getRepeatScheduleId())
+        .categoryId(repeatSchedule.getScheduleCategory().getScheduleCategoryId())
+        .startDt(repeatSchedule.getStartDt())
+        .endDt(repeatSchedule.getEndDt())
+        .title(repeatSchedule.getTitle())
+        .content(repeatSchedule.getContent())
+        .place(repeatSchedule.getPlace())
+        .repeatCycle(repeatSchedule.getRepeatCycle())
+        .month(repeatSchedule.getMonth())
+        .day(repeatSchedule.getDay())
+        .dayOfWeek(repeatSchedule.getDayOfWeek())
+        .teamParticipantsIds(
+            getTeamParticipantsIdsFromSchedules(repeatSchedule.getTeamParticipantsSchedules()))
+        .teamParticipantsNames(
+            getTeamParticipantsNameFromSchedules(repeatSchedule.getTeamParticipantsSchedules()))
+        .teamRoles(getTeamParticipantsRoleFromSchedules(repeatSchedule.getTeamParticipantsSchedules()))
+        .build();
+  }
+
+  public static List<Long> getTeamParticipantsIdsFromSchedules(
+      List<TeamParticipantsSchedule> teamParticipantsSchedules) {
+    List<Long> teamParticipantsIds = new ArrayList<>();
+    if (teamParticipantsSchedules != null) {
+      for (TeamParticipantsSchedule teamParticipantsSchedule : teamParticipantsSchedules) {
+        teamParticipantsIds.add(
+            teamParticipantsSchedule.getTeamParticipants().getTeamParticipantsId());
+      }
+    }
+    return teamParticipantsIds;
+  }
+
+  public static List<String> getTeamParticipantsNameFromSchedules(
+      List<TeamParticipantsSchedule> teamParticipantsSchedules) {
+    List<String> teamParticipantsNames = new ArrayList<>();
+    if (teamParticipantsSchedules != null) {
+      for (TeamParticipantsSchedule teamParticipantsSchedule : teamParticipantsSchedules) {
+        teamParticipantsNames.add(teamParticipantsSchedule.getTeamParticipants().getTeamNickName());
+      }
+    }
+    return teamParticipantsNames;
+  }
+
+  public static List<TeamRole> getTeamParticipantsRoleFromSchedules(
+      List<TeamParticipantsSchedule> teamParticipantsSchedules) {
+    List<TeamRole> teamParticipantsRoles = new ArrayList<>();
+    if (teamParticipantsSchedules != null) {
+      for (TeamParticipantsSchedule teamParticipantsSchedule : teamParticipantsSchedules) {
+        teamParticipantsRoles.add(teamParticipantsSchedule.getTeamParticipants().getTeamRole());
+      }
+    }
+    return teamParticipantsRoles;
+  }
+}

--- a/backend/src/main/java/com/api/backend/schedule/data/dto/ScheduleRequest.java
+++ b/backend/src/main/java/com/api/backend/schedule/data/dto/ScheduleRequest.java
@@ -33,7 +33,6 @@ public class ScheduleRequest {
   private LocalDateTime endDt;
 
   private String place;
-  private boolean isRepeat;
   private RepeatCycle repeatCycle;
   private String month;
   private int day;

--- a/backend/src/main/java/com/api/backend/schedule/data/dto/ScheduleResponse.java
+++ b/backend/src/main/java/com/api/backend/schedule/data/dto/ScheduleResponse.java
@@ -6,14 +6,14 @@ import com.api.backend.schedule.data.entity.TeamParticipantsSchedule;
 import com.api.backend.schedule.data.type.RepeatCycle;
 import com.api.backend.team.data.type.TeamRole;
 import com.fasterxml.jackson.annotation.JsonFormat;
-import java.time.LocalDateTime;
-import java.time.Month;
-import java.util.ArrayList;
-import java.util.List;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import org.springframework.data.domain.Page;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
 
 @Getter
 @Builder
@@ -29,55 +29,57 @@ public class ScheduleResponse {
   private String title;
   private String content;
   private String place;
-  private boolean isRepeat;
   private RepeatCycle repeatCycle;
-  private String month; //월: 연간 반복시 사용
-  private int day; //일: 연간, 월간 반복시 사용
-  private String dayOfWeek; //요일: 주간 반복시 사용
+  private String month;
+  private int day;
+  private String dayOfWeek;
   private List<Long> teamParticipantsIds;
   private List<String> teamParticipantsNames;
   private List<TeamRole> teamRoles;
-  private boolean isConverted;
 
-  public static ScheduleResponse from(SimpleSchedule simpleSchedule) {
-    return ScheduleResponse.builder()
-        .scheduleType("단순 일정")
-        .scheduleId(simpleSchedule.getSimpleScheduleId())
-        .categoryId(simpleSchedule.getScheduleCategory().getScheduleCategoryId())
-        .startDt(simpleSchedule.getStartDt())
-        .endDt(simpleSchedule.getEndDt())
-        .title(simpleSchedule.getTitle())
-        .content(simpleSchedule.getContent())
-        .place(simpleSchedule.getPlace())
-        .teamParticipantsIds(
-            getTeamParticipantsIdsFromSchedules(simpleSchedule.getTeamParticipantsSchedules()))
-        .teamParticipantsNames(
-            getTeamParticipantsNameFromSchedules(simpleSchedule.getTeamParticipantsSchedules()))
-        .teamRoles(getTeamParticipantsRoleFromSchedules(simpleSchedule.getTeamParticipantsSchedules()))
-        .build();
-  }
-  public static ScheduleResponse from(RepeatSchedule repeatSchedule) {
+  public static ScheduleResponse from(RepeatScheduleResponse repeatScheduleResponse) {
     return ScheduleResponse.builder()
         .scheduleType("반복 일정")
-        .scheduleId(repeatSchedule.getRepeatScheduleId())
-        .categoryId(repeatSchedule.getScheduleCategory().getScheduleCategoryId())
-        .startDt(repeatSchedule.getStartDt())
-        .endDt(repeatSchedule.getEndDt())
-        .title(repeatSchedule.getTitle())
-        .content(repeatSchedule.getContent())
-        .place(repeatSchedule.getPlace())
-        .day(repeatSchedule.getDay())
-        .month(repeatSchedule.getMonth())
-        .dayOfWeek(repeatSchedule.getDayOfWeek())
-        .teamParticipantsIds(
-            getTeamParticipantsIdsFromSchedules(repeatSchedule.getTeamParticipantsSchedules()))
-        .teamParticipantsNames(
-            getTeamParticipantsNameFromSchedules(repeatSchedule.getTeamParticipantsSchedules()))
-        .teamRoles(getTeamParticipantsRoleFromSchedules(repeatSchedule.getTeamParticipantsSchedules()))
+        .scheduleId(repeatScheduleResponse.getScheduleId())
+        .categoryId(repeatScheduleResponse.getCategoryId())
+        .startDt(repeatScheduleResponse.getStartDt())
+        .endDt(repeatScheduleResponse.getEndDt())
+        .title(repeatScheduleResponse.getTitle())
+        .content(repeatScheduleResponse.getContent())
+        .place(repeatScheduleResponse.getPlace())
+        .repeatCycle(repeatScheduleResponse.getRepeatCycle())
+        .month(repeatScheduleResponse.getMonth())
+        .day(repeatScheduleResponse.getDay())
+        .dayOfWeek(repeatScheduleResponse.getDayOfWeek())
+        .teamParticipantsIds(repeatScheduleResponse.getTeamParticipantsIds())
+        .teamParticipantsNames(repeatScheduleResponse.getTeamParticipantsNames())
+        .teamRoles(repeatScheduleResponse.getTeamRoles())
         .build();
   }
-  public static Page<ScheduleResponse> from(Page<SimpleSchedule> schedules) {
-    return schedules.map(ScheduleResponse::from);
+
+  public static ScheduleResponse from(SimpleScheduleResponse simpleScheduleResponse) {
+    return ScheduleResponse.builder()
+        .scheduleType("단순 일정")
+        .scheduleId(simpleScheduleResponse.getScheduleId())
+        .categoryId(simpleScheduleResponse.getCategoryId())
+        .startDt(simpleScheduleResponse.getStartDt())
+        .endDt(simpleScheduleResponse.getEndDt())
+        .title(simpleScheduleResponse.getTitle())
+        .content(simpleScheduleResponse.getContent())
+        .place(simpleScheduleResponse.getPlace())
+        .teamParticipantsIds(simpleScheduleResponse.getTeamParticipantsIds())
+        .teamParticipantsNames(simpleScheduleResponse.getTeamParticipantsNames())
+        .teamRoles(simpleScheduleResponse.getTeamRoles())
+        .build();
+  }
+
+
+  public static Page<RepeatScheduleResponse> fromRepeatSchedule(Page<RepeatSchedule> schedules) {
+    return schedules.map(RepeatScheduleResponse::from);
+  }
+
+  public static Page<SimpleScheduleResponse> fromSimpleSchedule(Page<SimpleSchedule> schedules) {
+    return schedules.map(SimpleScheduleResponse::from);
   }
 
   public static List<Long> getTeamParticipantsIdsFromSchedules(

--- a/backend/src/main/java/com/api/backend/schedule/data/dto/SimpleScheduleResponse.java
+++ b/backend/src/main/java/com/api/backend/schedule/data/dto/SimpleScheduleResponse.java
@@ -1,0 +1,82 @@
+package com.api.backend.schedule.data.dto;
+
+import com.api.backend.schedule.data.entity.SimpleSchedule;
+import com.api.backend.schedule.data.entity.TeamParticipantsSchedule;
+import com.api.backend.team.data.type.TeamRole;
+import com.fasterxml.jackson.annotation.JsonFormat;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+@AllArgsConstructor
+public class SimpleScheduleResponse {
+  private String scheduleType;
+  private Long scheduleId;
+  private Long categoryId;
+  @JsonFormat(pattern = "yyyy-MM-dd HH:mm")
+  private LocalDateTime startDt;
+  @JsonFormat(pattern = "yyyy-MM-dd HH:mm")
+  private LocalDateTime endDt;
+  private String title;
+  private String content;
+  private String place;
+  private List<Long> teamParticipantsIds;
+  private List<String> teamParticipantsNames;
+  private List<TeamRole> teamRoles;
+
+  public static SimpleScheduleResponse from(SimpleSchedule simpleSchedule) {
+    return SimpleScheduleResponse.builder()
+        .scheduleType("단순 일정")
+        .scheduleId(simpleSchedule.getSimpleScheduleId())
+        .categoryId(simpleSchedule.getScheduleCategory().getScheduleCategoryId())
+        .startDt(simpleSchedule.getStartDt())
+        .endDt(simpleSchedule.getEndDt())
+        .title(simpleSchedule.getTitle())
+        .content(simpleSchedule.getContent())
+        .place(simpleSchedule.getPlace())
+        .teamParticipantsIds(
+            getTeamParticipantsIdsFromSchedules(simpleSchedule.getTeamParticipantsSchedules()))
+        .teamParticipantsNames(
+            getTeamParticipantsNameFromSchedules(simpleSchedule.getTeamParticipantsSchedules()))
+        .teamRoles(getTeamParticipantsRoleFromSchedules(simpleSchedule.getTeamParticipantsSchedules()))
+        .build();
+  }
+  public static List<Long> getTeamParticipantsIdsFromSchedules(
+      List<TeamParticipantsSchedule> teamParticipantsSchedules) {
+    List<Long> teamParticipantsIds = new ArrayList<>();
+    if (teamParticipantsSchedules != null) {
+      for (TeamParticipantsSchedule teamParticipantsSchedule : teamParticipantsSchedules) {
+        teamParticipantsIds.add(
+            teamParticipantsSchedule.getTeamParticipants().getTeamParticipantsId());
+      }
+    }
+    return teamParticipantsIds;
+  }
+
+  public static List<String> getTeamParticipantsNameFromSchedules(
+      List<TeamParticipantsSchedule> teamParticipantsSchedules) {
+    List<String> teamParticipantsNames = new ArrayList<>();
+    if (teamParticipantsSchedules != null) {
+      for (TeamParticipantsSchedule teamParticipantsSchedule : teamParticipantsSchedules) {
+        teamParticipantsNames.add(teamParticipantsSchedule.getTeamParticipants().getTeamNickName());
+      }
+    }
+    return teamParticipantsNames;
+  }
+
+  public static List<TeamRole> getTeamParticipantsRoleFromSchedules(
+      List<TeamParticipantsSchedule> teamParticipantsSchedules) {
+    List<TeamRole> teamParticipantsRoles = new ArrayList<>();
+    if (teamParticipantsSchedules != null) {
+      for (TeamParticipantsSchedule teamParticipantsSchedule : teamParticipantsSchedules) {
+        teamParticipantsRoles.add(teamParticipantsSchedule.getTeamParticipants().getTeamRole());
+      }
+    }
+    return teamParticipantsRoles;
+  }
+}

--- a/backend/src/main/java/com/api/backend/schedule/data/repository/RepeatScheduleRepository.java
+++ b/backend/src/main/java/com/api/backend/schedule/data/repository/RepeatScheduleRepository.java
@@ -1,12 +1,18 @@
 package com.api.backend.schedule.data.repository;
 
+import com.api.backend.category.type.CategoryType;
 import com.api.backend.schedule.data.entity.RepeatSchedule;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface RepeatScheduleRepository extends JpaRepository<RepeatSchedule, Long> {
 
-  RepeatSchedule findRepeatScheduleByRepeatScheduleIdAndTeam_TeamId(Long repeatScheduleId, Long teamId);
   RepeatSchedule findByOriginRepeatScheduleId(Long originRepeatScheduleId);
+
+  Page<RepeatSchedule> findAllByTeam_TeamId(Long teamId, Pageable pageable);
+
+  Page<RepeatSchedule> findAllByScheduleCategory_CategoryTypeAndTeam_TeamId(CategoryType categoryType, Long teamId, Pageable pageable);
 }

--- a/backend/src/main/java/com/api/backend/schedule/data/repository/RepeatScheduleRepository.java
+++ b/backend/src/main/java/com/api/backend/schedule/data/repository/RepeatScheduleRepository.java
@@ -11,6 +11,7 @@ import org.springframework.stereotype.Repository;
 public interface RepeatScheduleRepository extends JpaRepository<RepeatSchedule, Long> {
 
   RepeatSchedule findByOriginRepeatScheduleId(Long originRepeatScheduleId);
+  RepeatSchedule findRepeatScheduleByRepeatScheduleIdAndTeam_TeamId(Long scheduleId, Long teamId);
 
   Page<RepeatSchedule> findAllByTeam_TeamId(Long teamId, Pageable pageable);
 

--- a/backend/src/main/java/com/api/backend/schedule/data/repository/SimpleScheduleRepository.java
+++ b/backend/src/main/java/com/api/backend/schedule/data/repository/SimpleScheduleRepository.java
@@ -2,7 +2,6 @@ package com.api.backend.schedule.data.repository;
 
 import com.api.backend.category.type.CategoryType;
 import com.api.backend.schedule.data.entity.SimpleSchedule;
-import java.time.LocalDateTime;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -13,10 +12,7 @@ public interface SimpleScheduleRepository extends JpaRepository<SimpleSchedule, 
 
   SimpleSchedule findSimpleScheduleBySimpleScheduleIdAndTeam_TeamId(Long scheduleId, Long teamId);
 
-  Page<SimpleSchedule> findByTeam_TeamIdAndStartDtBetweenAndScheduleCategory_CategoryType(Long teamId, LocalDateTime startDt,
-      LocalDateTime endDt, CategoryType type, Pageable pageable);
+  Page<SimpleSchedule> findAllByTeam_TeamId(Long teamId, Pageable pageable);
 
-
-  Page<SimpleSchedule> findByTeam_TeamIdAndStartDtBetween(Long teamId, LocalDateTime startDt,
-      LocalDateTime endDt, Pageable pageable);
+  Page<SimpleSchedule> findAllByScheduleCategory_CategoryTypeAndTeam_TeamId(CategoryType categoryType, Long teamId, Pageable pageable);
 }

--- a/backend/src/main/java/com/api/backend/schedule/service/ScheduleService.java
+++ b/backend/src/main/java/com/api/backend/schedule/service/ScheduleService.java
@@ -28,6 +28,7 @@ import com.api.backend.team.data.entity.Team;
 import com.api.backend.team.data.entity.TeamParticipants;
 import com.api.backend.team.data.repository.TeamParticipantsRepository;
 import com.api.backend.team.data.repository.TeamRepository;
+import java.security.Principal;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
@@ -54,7 +55,7 @@ public class ScheduleService {
 
 
   @Transactional
-  public SimpleSchedule addSimpleScheduleAndSave(ScheduleRequest scheduleRequest) {
+  public SimpleSchedule addSimpleScheduleAndSave(ScheduleRequest scheduleRequest, Principal principal) {
     Team team = findTeamOrElseThrow(scheduleRequest.getTeamId());
     ScheduleCategory category = findScheduleCategoryOrElseThrow(scheduleRequest.getCategoryId());
 
@@ -68,7 +69,7 @@ public class ScheduleService {
   }
 
   @Transactional
-  public RepeatSchedule addRepeatScheduleAndSave(ScheduleRequest scheduleRequest) {
+  public RepeatSchedule addRepeatScheduleAndSave(ScheduleRequest scheduleRequest, Principal principal) {
     Team team = findTeamOrElseThrow(scheduleRequest.getTeamId());
     ScheduleCategory category = findScheduleCategoryOrElseThrow(scheduleRequest.getCategoryId());
 
@@ -86,7 +87,7 @@ public class ScheduleService {
   }
 
   @Transactional
-  public SimpleSchedule editSimpleScheduleInfoAndSave(SimpleScheduleInfoEditRequest editRequest) {
+  public SimpleSchedule editSimpleScheduleInfoAndSave(SimpleScheduleInfoEditRequest editRequest, Principal principal) {
     Team team = findTeamOrElseThrow(editRequest.getTeamId());
     ScheduleCategory category = findScheduleCategoryOrElseThrow(editRequest.getCategoryId());
     List<Long> teamParticipantsIds = editRequest.getTeamParticipantsIds();
@@ -117,7 +118,7 @@ public class ScheduleService {
   }
 
   @Transactional
-  public RepeatSchedule editRepeatScheduleInfoAndSave(RepeatScheduleInfoEditRequest editRequest) {
+  public RepeatSchedule editRepeatScheduleInfoAndSave(RepeatScheduleInfoEditRequest editRequest, Principal principal) {
     Team team = findTeamOrElseThrow(editRequest.getTeamId());
     ScheduleCategory category = findScheduleCategoryOrElseThrow(editRequest.getCategoryId());
     List<Long> teamParticipantsIds = editRequest.getTeamParticipantsIds();
@@ -187,33 +188,33 @@ public class ScheduleService {
 
 
   @Transactional
-  public void deleteSimpleSchedule(Long scheduleId) {
+  public void deleteSimpleSchedule(Long scheduleId, Principal principal) {
     SimpleSchedule simpleSchedule = simpleScheduleRepository.findById(scheduleId)
         .orElseThrow(() -> new CustomException(SCHEDULE_NOT_FOUND_EXCEPTION));
     simpleScheduleRepository.delete(simpleSchedule);
   }
 
   @Transactional
-  public void deleteRepeatSchedule(Long scheduleId) {
+  public void deleteRepeatSchedule(Long scheduleId, Principal principal) {
     RepeatSchedule repeatSchedule = repeatScheduleRepository.findById(scheduleId)
         .orElseThrow(() -> new CustomException(SCHEDULE_NOT_FOUND_EXCEPTION));
     repeatScheduleRepository.delete(repeatSchedule);
   }
 
-  public SimpleSchedule getSimpleScheduleDetailInfo(Long scheduleId, Long teamId) {
+  public SimpleSchedule getSimpleScheduleDetailInfo(Long scheduleId, Long teamId, Principal principal) {
     findTeamOrElseThrow(teamId);
     return simpleScheduleRepository.findSimpleScheduleBySimpleScheduleIdAndTeam_TeamId(scheduleId,
         teamId);
   }
 
-  public RepeatSchedule getRepeatScheduleDetailInfo(Long scheduleId, Long teamId) {
+  public RepeatSchedule getRepeatScheduleDetailInfo(Long scheduleId, Long teamId, Principal principal) {
     findTeamOrElseThrow(teamId);
     return repeatScheduleRepository.findRepeatScheduleByRepeatScheduleIdAndTeam_TeamId(scheduleId,
         teamId);
   }
 
 
-  public Page<AllSchedulesMonthlyView> getCategoryTypeMonthlySchedules(Long teamId, CategoryType categoryType, Pageable pageable) {
+  public Page<AllSchedulesMonthlyView> getCategoryTypeMonthlySchedules(Long teamId, CategoryType categoryType, Pageable pageable, Principal principal) {
     Page<RepeatSchedule> repeatSchedules = repeatScheduleRepository.findAllByScheduleCategory_CategoryTypeAndTeam_TeamId(
         categoryType, teamId, pageable);
     Page<SimpleSchedule> simpleSchedules = simpleScheduleRepository.findAllByScheduleCategory_CategoryTypeAndTeam_TeamId(
@@ -229,7 +230,7 @@ public class ScheduleService {
     );
   }
 
-  public Page<AllSchedulesMonthlyView> getAllMonthlySchedules(Long teamId, Pageable pageable) {
+  public Page<AllSchedulesMonthlyView> getAllMonthlySchedules(Long teamId, Pageable pageable, Principal principal) {
     Page<RepeatSchedule> repeatSchedules = repeatScheduleRepository.findAllByTeam_TeamId(
          teamId, pageable);
     Page<SimpleSchedule> simpleSchedules = simpleScheduleRepository.findAllByTeam_TeamId(

--- a/backend/src/main/java/com/api/backend/schedule/service/ScheduleService.java
+++ b/backend/src/main/java/com/api/backend/schedule/service/ScheduleService.java
@@ -200,9 +200,15 @@ public class ScheduleService {
     repeatScheduleRepository.delete(repeatSchedule);
   }
 
-  public SimpleSchedule searchScheduleDetailInfo(Long scheduleId, Long teamId) {
+  public SimpleSchedule getSimpleScheduleDetailInfo(Long scheduleId, Long teamId) {
     findTeamOrElseThrow(teamId);
     return simpleScheduleRepository.findSimpleScheduleBySimpleScheduleIdAndTeam_TeamId(scheduleId,
+        teamId);
+  }
+
+  public RepeatSchedule getRepeatScheduleDetailInfo(Long scheduleId, Long teamId) {
+    findTeamOrElseThrow(teamId);
+    return repeatScheduleRepository.findRepeatScheduleByRepeatScheduleIdAndTeam_TeamId(scheduleId,
         teamId);
   }
 

--- a/backend/src/main/java/com/api/backend/schedule/service/ScheduleService.java
+++ b/backend/src/main/java/com/api/backend/schedule/service/ScheduleService.java
@@ -12,9 +12,9 @@ import com.api.backend.category.data.repository.ScheduleCategoryRepository;
 import com.api.backend.category.type.CategoryType;
 import com.api.backend.global.exception.CustomException;
 import com.api.backend.global.exception.type.ErrorCode;
+import com.api.backend.schedule.data.dto.AllSchedulesMonthlyView;
 import com.api.backend.schedule.data.dto.RepeatScheduleInfoEditRequest;
 import com.api.backend.schedule.data.dto.ScheduleRequest;
-import com.api.backend.schedule.data.dto.ScheduleResponse;
 import com.api.backend.schedule.data.dto.SimpleScheduleInfoEditRequest;
 import com.api.backend.schedule.data.entity.RepeatSchedule;
 import com.api.backend.schedule.data.entity.SimpleSchedule;
@@ -28,16 +28,16 @@ import com.api.backend.team.data.entity.Team;
 import com.api.backend.team.data.entity.TeamParticipants;
 import com.api.backend.team.data.repository.TeamParticipantsRepository;
 import com.api.backend.team.data.repository.TeamRepository;
-import java.time.LocalDate;
-import java.time.LocalDateTime;
-import java.time.LocalTime;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 import javax.transaction.Transactional;
 import lombok.AllArgsConstructor;
 import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 
@@ -206,19 +206,37 @@ public class ScheduleService {
         teamId);
   }
 
-  public Page<ScheduleResponse> getSchedulesForMonth(Long teamId, LocalDate monthStart,
-      LocalDate monthEnd, CategoryType type, Pageable pageable) {
-    LocalDateTime startDt = monthStart.atStartOfDay();
-    LocalDateTime endDt = monthEnd.atTime(LocalTime.MAX);
-    Page<SimpleSchedule> schedules;
-    if (type != null) {
-      schedules = simpleScheduleRepository.findByTeam_TeamIdAndStartDtBetweenAndScheduleCategory_CategoryType(
-          teamId, startDt, endDt, type, pageable);
-    } else {
-      schedules = simpleScheduleRepository.findByTeam_TeamIdAndStartDtBetween(teamId, startDt,
-          endDt, pageable);
-    }
-    return ScheduleResponse.from(schedules);
+
+  public Page<AllSchedulesMonthlyView> getCategoryTypeMonthlySchedules(Long teamId, CategoryType categoryType, Pageable pageable) {
+    Page<RepeatSchedule> repeatSchedules = repeatScheduleRepository.findAllByScheduleCategory_CategoryTypeAndTeam_TeamId(
+        categoryType, teamId, pageable);
+    Page<SimpleSchedule> simpleSchedules = simpleScheduleRepository.findAllByScheduleCategory_CategoryTypeAndTeam_TeamId(
+        categoryType, teamId, pageable);
+
+    List<AllSchedulesMonthlyView> allSchedulesList = Stream.concat(
+        repeatSchedules.getContent().stream().map(AllSchedulesMonthlyView::from),
+        simpleSchedules.getContent().stream().map(AllSchedulesMonthlyView::from)
+    ).collect(Collectors.toList());
+
+    return new PageImpl<>(allSchedulesList, pageable,
+        repeatSchedules.getTotalElements() + simpleSchedules.getTotalElements()
+    );
+  }
+
+  public Page<AllSchedulesMonthlyView> getAllMonthlySchedules(Long teamId, Pageable pageable) {
+    Page<RepeatSchedule> repeatSchedules = repeatScheduleRepository.findAllByTeam_TeamId(
+         teamId, pageable);
+    Page<SimpleSchedule> simpleSchedules = simpleScheduleRepository.findAllByTeam_TeamId(
+         teamId, pageable);
+
+    List<AllSchedulesMonthlyView> allSchedulesList = Stream.concat(
+        repeatSchedules.getContent().stream().map(AllSchedulesMonthlyView::from),
+        simpleSchedules.getContent().stream().map(AllSchedulesMonthlyView::from)
+    ).collect(Collectors.toList());
+
+    return new PageImpl<>(allSchedulesList, pageable,
+        repeatSchedules.getTotalElements() + simpleSchedules.getTotalElements()
+    );
   }
 
   private SimpleSchedule findSimpleScheduleOrElseThrow(Long simpleScheduleId) {


### PR DESCRIPTION
### 변경 내용
<!-- 여기에 변경한 내용을 명시해주세요. -->

AS-IS
- Swagger, Security 미적용
- 일정 추가시 일정 유형에 관계 없이 ScheduleResponse로만 응답

TO-BE
- Swagger, Security 적용
- 단순/반복 일정 상세 조회 
- 일정 추가시 일정 유형에 맞는 Response로 변환 후 ScheduleResponse로 응답
- 월간보기 (카테고리 입력 여부에 따라 유형별 조회 가능)

### 테스트
<!-- 본 변경사항이 테스트가 되었는지 기술해주세요 --> 
* [ ] 테스트 코드
* [x] API 테스트

### 관련 이슈
<!-- 이 PR과 관련된 이슈 번호를 명시해주세요. 예: #123 -->

### 변경 사항 검토
* [ ] api 문서 업데이트

### 특이 사항
<!-- 리뷰어에게 특별히 주의해야 할 사항이나 테스트할 때 필요한 추가 정보를 여기에 적어주세요. -->
ScheduleResponse로 왜 한번 더 변환하는지에 대해 말씀드리겠습니다.

일반적으로 , 사용자가 일정을 생성할 때 반복 여부를 미리 선택하지 않고, 
일정 추가 페이지 내에서 선택하는 경우가 대부분입니다. 
따라서 각 일정의 반복 여부 및 정보를 입력 후, 일정 유형에 따른 response로 변환 후에 (null 없애기 위해)
최종적으로 ScheduleResponse로 변환하는 과정을 거쳤습니다. 

### 스크린샷 (선택 사항)
<!-- 필요한 경우 변경 내용에 대한 스크린샷을 첨부하세요. -->