### PR TITLE
Refactor/calendar schedule

### DIFF
--- a/backend/src/main/java/com/api/backend/schedule/controller/ScheduleController.java
+++ b/backend/src/main/java/com/api/backend/schedule/controller/ScheduleController.java
@@ -5,6 +5,8 @@ import com.api.backend.schedule.data.dto.AllSchedulesMonthlyView;
 import com.api.backend.schedule.data.dto.RepeatScheduleInfoEditRequest;
 import com.api.backend.schedule.data.dto.RepeatScheduleInfoEditResponse;
 import com.api.backend.schedule.data.dto.RepeatScheduleResponse;
+import com.api.backend.schedule.data.dto.RepeatToSimpleScheduleEditRequest;
+import com.api.backend.schedule.data.dto.ScheduleTypeConverterResponse;
 import com.api.backend.schedule.data.dto.ScheduleRequest;
 import com.api.backend.schedule.data.dto.ScheduleResponse;
 import com.api.backend.schedule.data.dto.SimpleScheduleInfoEditRequest;
@@ -296,7 +298,41 @@ public class ScheduleController {
         scheduleService.editRepeatScheduleInfoAndSave(editRequest, principal));
     return ResponseEntity.ok(response);
   }
-
+  @ApiOperation(value = "반복일정 -> 단순일정으로 변경")
+  @ApiResponses(value = {
+      @ApiResponse(code = 200, message = "일정이 성공적으로 수정되었습니다."),
+      @ApiResponse(code = 404, message = "페이지를 찾을 수 없습니다."),
+      @ApiResponse(code = 400, message = "일정 수정에 실패했습니다.")
+  })
+  @ApiImplicitParams(
+      {
+          @ApiImplicitParam(
+              name = "access token"
+              , value = "jwt access token"
+              , required = true
+              , dataType = "String"
+              , paramType = "header"
+              , defaultValue = "None"),
+          @ApiImplicitParam(
+              name = "teamId"
+              , value = "팀 id"
+              , required = true
+              , dataType = "Long"
+              , paramType = "path"
+              , defaultValue = "None"
+              , example = "1")
+      })
+  @PutMapping("/convert-repeat-to-simple")
+  public ResponseEntity<ScheduleTypeConverterResponse> convertRepeatToSimpleSchedule(
+      @PathVariable Long teamId,
+      @RequestBody @Valid RepeatToSimpleScheduleEditRequest editRequest,
+      @ApiIgnore Principal principal
+  ) {
+    ScheduleTypeConverterResponse response = ScheduleTypeConverterResponse.from(
+        scheduleService.convertRepeatToSimpleSchedule(editRequest, principal)
+    );
+    return ResponseEntity.ok(response);
+  }
 
   @ApiOperation(value = "단순일정 삭제")
   @ApiResponses(value = {

--- a/backend/src/main/java/com/api/backend/schedule/controller/ScheduleController.java
+++ b/backend/src/main/java/com/api/backend/schedule/controller/ScheduleController.java
@@ -3,11 +3,12 @@ package com.api.backend.schedule.controller;
 import com.api.backend.category.type.CategoryType;
 import com.api.backend.schedule.data.dto.AllSchedulesMonthlyView;
 import com.api.backend.schedule.data.dto.RepeatScheduleInfoEditRequest;
+import com.api.backend.schedule.data.dto.RepeatScheduleInfoEditResponse;
 import com.api.backend.schedule.data.dto.RepeatScheduleResponse;
-import com.api.backend.schedule.data.dto.ScheduleEditResponse;
 import com.api.backend.schedule.data.dto.ScheduleRequest;
 import com.api.backend.schedule.data.dto.ScheduleResponse;
 import com.api.backend.schedule.data.dto.SimpleScheduleInfoEditRequest;
+import com.api.backend.schedule.data.dto.SimpleScheduleInfoEditResponse;
 import com.api.backend.schedule.data.dto.SimpleScheduleResponse;
 import com.api.backend.schedule.service.ScheduleService;
 import io.swagger.annotations.Api;
@@ -249,12 +250,12 @@ public class ScheduleController {
               , example = "1")
       })
   @PutMapping("/simple")
-  public ResponseEntity<ScheduleEditResponse> editSimpleSchedule(
+  public ResponseEntity<SimpleScheduleInfoEditResponse> editSimpleSchedule(
       @PathVariable Long teamId,
       @RequestBody @Valid SimpleScheduleInfoEditRequest editRequest,
       @ApiIgnore Principal principal
   ) {
-    ScheduleEditResponse response = ScheduleEditResponse.from(
+    SimpleScheduleInfoEditResponse response = SimpleScheduleInfoEditResponse.from(
         scheduleService.editSimpleScheduleInfoAndSave(editRequest, principal)
     );
     return ResponseEntity.ok(response);
@@ -286,12 +287,12 @@ public class ScheduleController {
               , example = "1")
       })
   @PutMapping("/repeat")
-  public ResponseEntity<ScheduleEditResponse> editRepeatSchedule(
+  public ResponseEntity<RepeatScheduleInfoEditResponse> editRepeatSchedule(
       @PathVariable Long teamId,
       @RequestBody @Valid RepeatScheduleInfoEditRequest editRequest,
       @ApiIgnore Principal principal
   ) {
-    ScheduleEditResponse response = ScheduleEditResponse.from(
+    RepeatScheduleInfoEditResponse response = RepeatScheduleInfoEditResponse.from(
         scheduleService.editRepeatScheduleInfoAndSave(editRequest, principal));
     return ResponseEntity.ok(response);
   }

--- a/backend/src/main/java/com/api/backend/schedule/controller/ScheduleController.java
+++ b/backend/src/main/java/com/api/backend/schedule/controller/ScheduleController.java
@@ -12,6 +12,7 @@ import com.api.backend.schedule.data.dto.ScheduleResponse;
 import com.api.backend.schedule.data.dto.SimpleScheduleInfoEditRequest;
 import com.api.backend.schedule.data.dto.SimpleScheduleInfoEditResponse;
 import com.api.backend.schedule.data.dto.SimpleScheduleResponse;
+import com.api.backend.schedule.data.dto.SimpleToRepeatScheduleEditRequest;
 import com.api.backend.schedule.service.ScheduleService;
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiImplicitParam;
@@ -334,6 +335,45 @@ public class ScheduleController {
     return ResponseEntity.ok(response);
   }
 
+
+  @ApiOperation(value = "단순일정 -> 반복일정으로 변경")
+  @ApiResponses(value = {
+      @ApiResponse(code = 200, message = "일정이 성공적으로 수정되었습니다."),
+      @ApiResponse(code = 404, message = "페이지를 찾을 수 없습니다."),
+      @ApiResponse(code = 400, message = "일정 수정에 실패했습니다.")
+  })
+  @ApiImplicitParams(
+      {
+          @ApiImplicitParam(
+              name = "access token"
+              , value = "jwt access token"
+              , required = true
+              , dataType = "String"
+              , paramType = "header"
+              , defaultValue = "None"),
+          @ApiImplicitParam(
+              name = "teamId"
+              , value = "팀 id"
+              , required = true
+              , dataType = "Long"
+              , paramType = "path"
+              , defaultValue = "None"
+              , example = "1")
+      })
+  @PutMapping("/convert-simple-to-repeat")
+  public ResponseEntity<ScheduleTypeConverterResponse> convertSimpleToRepeatSchedule(
+      @PathVariable Long teamId,
+      @RequestBody @Valid SimpleToRepeatScheduleEditRequest editRequest,
+      @ApiIgnore Principal principal
+  ) {
+    ScheduleTypeConverterResponse response = ScheduleTypeConverterResponse.from(
+        scheduleService.convertSimpleToRepeatSchedule(editRequest, principal)
+    );
+    return ResponseEntity.ok(response);
+  }
+
+
+
   @ApiOperation(value = "단순일정 삭제")
   @ApiResponses(value = {
       @ApiResponse(code = 200, message = "일정이 성공적으로 삭제되었습니다."),
@@ -418,4 +458,5 @@ public class ScheduleController {
     scheduleService.deleteRepeatSchedule(scheduleId, principal);
     return ResponseEntity.ok("해당 반복 일정이 정상적으로 삭제되었습니다.");
   }
+
 }

--- a/backend/src/main/java/com/api/backend/schedule/data/dto/AllSchedulesMonthlyView.java
+++ b/backend/src/main/java/com/api/backend/schedule/data/dto/AllSchedulesMonthlyView.java
@@ -1,6 +1,5 @@
 package com.api.backend.schedule.data.dto;
 
-import com.api.backend.category.data.entity.ScheduleCategory;
 import com.api.backend.category.type.CategoryType;
 import com.api.backend.schedule.data.entity.RepeatSchedule;
 import com.api.backend.schedule.data.entity.SimpleSchedule;
@@ -15,8 +14,11 @@ import org.springframework.data.domain.Page;
 @AllArgsConstructor
 @Builder
 public class AllSchedulesMonthlyView {
+
   private Long scheduleId;
+  private String scheduleType;
   private CategoryType category;
+  private String categoryName;
   private String title;
   private String content;
   private String place;
@@ -25,41 +27,44 @@ public class AllSchedulesMonthlyView {
   @JsonFormat(pattern = "yyyy-MM-dd HH:mm")
   private LocalDateTime endDt;
   private String color;
-  private String scheduleType;
 
   public static AllSchedulesMonthlyView from(RepeatSchedule repeatSchedule) {
     return AllSchedulesMonthlyView.builder()
         .scheduleId(repeatSchedule.getRepeatScheduleId())
+        .scheduleType("반복일정")
         .category(repeatSchedule.getScheduleCategory().getCategoryType())
+        .categoryName(repeatSchedule.getScheduleCategory().getCategoryName())
         .title(repeatSchedule.getTitle())
         .content(repeatSchedule.getContent())
         .place(repeatSchedule.getPlace())
         .startDt(repeatSchedule.getStartDt())
         .endDt(repeatSchedule.getEndDt())
         .color(repeatSchedule.getColor())
-        .scheduleType("반복일정")
         .build();
   }
 
   public static AllSchedulesMonthlyView from(SimpleSchedule simpleSchedule) {
     return AllSchedulesMonthlyView.builder()
         .scheduleId(simpleSchedule.getSimpleScheduleId())
+        .scheduleType("단순일정")
         .category(simpleSchedule.getScheduleCategory().getCategoryType())
+        .categoryName(simpleSchedule.getScheduleCategory().getCategoryName())
         .title(simpleSchedule.getTitle())
         .content(simpleSchedule.getContent())
         .place(simpleSchedule.getPlace())
         .startDt(simpleSchedule.getStartDt())
         .endDt(simpleSchedule.getEndDt())
         .color(simpleSchedule.getColor())
-        .scheduleType("단순일정")
         .build();
   }
 
-  public static Page<AllSchedulesMonthlyView> fromSimpleSchedulePage(Page<SimpleSchedule> simpleSchedules) {
+  public static Page<AllSchedulesMonthlyView> fromSimpleSchedulePage(
+      Page<SimpleSchedule> simpleSchedules) {
     return simpleSchedules.map(AllSchedulesMonthlyView::from);
   }
 
-  public static Page<AllSchedulesMonthlyView> fromRepeatSchedulePage(Page<RepeatSchedule> repeatSchedules) {
+  public static Page<AllSchedulesMonthlyView> fromRepeatSchedulePage(
+      Page<RepeatSchedule> repeatSchedules) {
     return repeatSchedules.map(AllSchedulesMonthlyView::from);
   }
 }

--- a/backend/src/main/java/com/api/backend/schedule/data/dto/RepeatScheduleInfoEditRequest.java
+++ b/backend/src/main/java/com/api/backend/schedule/data/dto/RepeatScheduleInfoEditRequest.java
@@ -10,29 +10,25 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 
+//반복 일정 정보만 수정
 @Getter
 @AllArgsConstructor
 @Builder
 @StartAndEndDtCheck(scheduleStart = "startDt", scheduleEnd = "endDt")
 public class RepeatScheduleInfoEditRequest {
+
   private Long repeatScheduleId;
   private Long teamId;
   private Long categoryId;
   private String title;
   private String content;
-  private String place;
-
   @JsonFormat(pattern = "yyyy-MM-dd HH:mm")
   private LocalDateTime startDt;
-
   @JsonFormat(pattern = "yyyy-MM-dd HH:mm")
   private LocalDateTime endDt;
-
-  private RepeatCycle repeatCycle;
-  private String month;
-  private int day;
-  private String dayOfWeek;
-  private List<Long> teamParticipantsIds;
+  private String place;
   private String color;
+  private RepeatCycle repeatCycle;
+  private List<Long> teamParticipantsIds;
   private EditOption editOption;
 }

--- a/backend/src/main/java/com/api/backend/schedule/data/dto/RepeatScheduleInfoEditResponse.java
+++ b/backend/src/main/java/com/api/backend/schedule/data/dto/RepeatScheduleInfoEditResponse.java
@@ -1,0 +1,94 @@
+package com.api.backend.schedule.data.dto;
+
+import com.api.backend.schedule.data.entity.RepeatSchedule;
+import com.api.backend.schedule.data.entity.TeamParticipantsSchedule;
+import com.api.backend.schedule.data.type.RepeatCycle;
+import com.api.backend.team.data.type.TeamRole;
+import com.fasterxml.jackson.annotation.JsonFormat;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+@AllArgsConstructor
+public class RepeatScheduleInfoEditResponse {
+  private Long scheduleId;
+  private Long originRepeatScheduleId;
+  private String scheduleType;
+  private String categoryName;
+  @JsonFormat(pattern = "yyyy-MM-dd HH:mm")
+  private LocalDateTime startDt;
+  @JsonFormat(pattern = "yyyy-MM-dd HH:mm")
+  private LocalDateTime endDt;
+  private String title;
+  private String content;
+  private String place;
+  private String color;
+  private RepeatCycle repeatCycle;
+  private String month;
+  private int day;
+  private String dayOfWeek;
+  private List<Long> teamParticipantsIds;
+  private List<String> teamParticipantsNames;
+  private List<TeamRole> teamRoles;
+
+  public static RepeatScheduleInfoEditResponse from(RepeatSchedule repeatSchedule) {
+    return RepeatScheduleInfoEditResponse.builder()
+        .scheduleId(repeatSchedule.getRepeatScheduleId())
+        .originRepeatScheduleId(repeatSchedule.getOriginRepeatScheduleId())
+        .scheduleType("반복 일정")
+        .categoryName(repeatSchedule.getScheduleCategory().getCategoryName())
+        .startDt(repeatSchedule.getStartDt())
+        .endDt(repeatSchedule.getEndDt())
+        .title(repeatSchedule.getTitle())
+        .content(repeatSchedule.getContent())
+        .place(repeatSchedule.getPlace())
+        .color(repeatSchedule.getColor())
+        .repeatCycle(repeatSchedule.getRepeatCycle())
+        .month(repeatSchedule.getMonth())
+        .day(repeatSchedule.getDay())
+        .dayOfWeek(repeatSchedule.getDayOfWeek())
+        .teamParticipantsIds(getTeamParticipantsIdsFromSchedules(repeatSchedule.getTeamParticipantsSchedules()))
+        .teamParticipantsNames(getTeamParticipantsNameFromSchedules(repeatSchedule.getTeamParticipantsSchedules()))
+        .teamRoles(getTeamParticipantsRoleFromSchedules(repeatSchedule.getTeamParticipantsSchedules()))
+        .build();
+  }
+
+  public static List<Long> getTeamParticipantsIdsFromSchedules(
+      List<TeamParticipantsSchedule> teamParticipantsSchedules) {
+    List<Long> teamParticipantsIds = new ArrayList<>();
+    if (teamParticipantsSchedules != null) {
+      for (TeamParticipantsSchedule teamParticipantsSchedule : teamParticipantsSchedules) {
+        teamParticipantsIds.add(
+            teamParticipantsSchedule.getTeamParticipants().getTeamParticipantsId());
+      }
+    }
+    return teamParticipantsIds;
+  }
+
+  public static List<String> getTeamParticipantsNameFromSchedules(
+      List<TeamParticipantsSchedule> teamParticipantsSchedules) {
+    List<String> teamParticipantsNames = new ArrayList<>();
+    if (teamParticipantsSchedules != null) {
+      for (TeamParticipantsSchedule teamParticipantsSchedule : teamParticipantsSchedules) {
+        teamParticipantsNames.add(teamParticipantsSchedule.getTeamParticipants().getTeamNickName());
+      }
+    }
+    return teamParticipantsNames;
+  }
+
+  public static List<TeamRole> getTeamParticipantsRoleFromSchedules(
+      List<TeamParticipantsSchedule> teamParticipantsSchedules) {
+    List<TeamRole> teamParticipantsRoles = new ArrayList<>();
+    if (teamParticipantsSchedules != null) {
+      for (TeamParticipantsSchedule teamParticipantsSchedule : teamParticipantsSchedules) {
+        teamParticipantsRoles.add(teamParticipantsSchedule.getTeamParticipants().getTeamRole());
+      }
+    }
+    return teamParticipantsRoles;
+  }
+}

--- a/backend/src/main/java/com/api/backend/schedule/data/dto/RepeatScheduleResponse.java
+++ b/backend/src/main/java/com/api/backend/schedule/data/dto/RepeatScheduleResponse.java
@@ -16,10 +16,9 @@ import lombok.Getter;
 @Builder
 @AllArgsConstructor
 public class RepeatScheduleResponse {
-
-  private String scheduleType;
   private Long scheduleId;
-  private Long categoryId;
+  private String scheduleType;
+  private String categoryName;
   @JsonFormat(pattern = "yyyy-MM-dd HH:mm")
   private LocalDateTime startDt;
   @JsonFormat(pattern = "yyyy-MM-dd HH:mm")
@@ -27,6 +26,7 @@ public class RepeatScheduleResponse {
   private String title;
   private String content;
   private String place;
+  private String color;
   private RepeatCycle repeatCycle;
   private String month;
   private int day;
@@ -37,9 +37,8 @@ public class RepeatScheduleResponse {
 
   public static RepeatScheduleResponse from(RepeatSchedule repeatSchedule) {
     return RepeatScheduleResponse.builder()
-        .scheduleType("단순 일정")
-        .scheduleId(repeatSchedule.getRepeatScheduleId())
-        .categoryId(repeatSchedule.getScheduleCategory().getScheduleCategoryId())
+        .scheduleType("반복 일정")
+        .categoryName(repeatSchedule.getScheduleCategory().getCategoryName())
         .startDt(repeatSchedule.getStartDt())
         .endDt(repeatSchedule.getEndDt())
         .title(repeatSchedule.getTitle())

--- a/backend/src/main/java/com/api/backend/schedule/data/dto/RepeatToSimpleScheduleEditRequest.java
+++ b/backend/src/main/java/com/api/backend/schedule/data/dto/RepeatToSimpleScheduleEditRequest.java
@@ -1,7 +1,6 @@
 package com.api.backend.schedule.data.dto;
 
 import com.api.backend.schedule.customValidAnnotation.StartAndEndDtCheck;
-import com.api.backend.schedule.data.type.EditOption;
 import com.fasterxml.jackson.annotation.JsonFormat;
 import java.time.LocalDateTime;
 import java.util.List;
@@ -15,6 +14,7 @@ import lombok.Getter;
 @StartAndEndDtCheck(scheduleStart = "startDt", scheduleEnd = "endDt")
 //반복일정  -> 단순일정
 public class RepeatToSimpleScheduleEditRequest {
+
   private Long repeatScheduleId;
   private Long teamId;
   private Long categoryId;
@@ -22,14 +22,10 @@ public class RepeatToSimpleScheduleEditRequest {
   private String content;
   @JsonFormat(pattern = "yyyy-MM-dd HH:mm")
   private LocalDateTime startDt;
-
   @JsonFormat(pattern = "yyyy-MM-dd HH:mm")
   private LocalDateTime endDt;
-
   private String place;
   private List<Long> teamParticipantsIds;
   private String color;
-  private EditOption editOption;
-  private Long originRepeatScheduleId;
-  private boolean isConverted;
+
 }

--- a/backend/src/main/java/com/api/backend/schedule/data/dto/ScheduleEditResponse.java
+++ b/backend/src/main/java/com/api/backend/schedule/data/dto/ScheduleEditResponse.java
@@ -15,9 +15,8 @@ import lombok.Getter;
 @Builder
 @AllArgsConstructor
 public class ScheduleEditResponse {
-
   private Long scheduleId;
-  private Long categoryId;
+  private String categoryName;
   private String title;
   private String content;
   @JsonFormat(pattern = "yyyy-MM-dd HH:mm")
@@ -30,11 +29,11 @@ public class ScheduleEditResponse {
   private List<Long> teamParticipantsIds;
   private List<String> teamParticipantsNames;
   private List<TeamRole> teamRoles;
+  private boolean isConverted;
 
   public static ScheduleEditResponse from(SimpleSchedule simpleSchedule) {
     return ScheduleEditResponse.builder()
-        .scheduleId(simpleSchedule.getSimpleScheduleId())
-        .categoryId(simpleSchedule.getScheduleCategory().getScheduleCategoryId())
+        .categoryName(simpleSchedule.getScheduleCategory().getCategoryName())
         .startDt(simpleSchedule.getStartDt())
         .endDt(simpleSchedule.getEndDt())
         .title(simpleSchedule.getTitle())
@@ -48,8 +47,7 @@ public class ScheduleEditResponse {
 
   public static ScheduleEditResponse from(RepeatSchedule repeatSchedule) {
     return ScheduleEditResponse.builder()
-        .scheduleId(repeatSchedule.getRepeatScheduleId())
-        .categoryId(repeatSchedule.getScheduleCategory().getScheduleCategoryId())
+        .categoryName(repeatSchedule.getScheduleCategory().getCategoryName())
         .startDt(repeatSchedule.getStartDt())
         .endDt(repeatSchedule.getEndDt())
         .title(repeatSchedule.getTitle())

--- a/backend/src/main/java/com/api/backend/schedule/data/dto/ScheduleRequest.java
+++ b/backend/src/main/java/com/api/backend/schedule/data/dto/ScheduleRequest.java
@@ -4,7 +4,6 @@ import com.api.backend.schedule.customValidAnnotation.StartAndEndDtCheck;
 import com.api.backend.schedule.data.type.RepeatCycle;
 import com.fasterxml.jackson.annotation.JsonFormat;
 import java.time.LocalDateTime;
-import java.time.Month;
 import java.util.List;
 import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.Size;
@@ -18,25 +17,19 @@ import lombok.Getter;
 
 @StartAndEndDtCheck(scheduleStart = "startDt", scheduleEnd = "endDt")
 public class ScheduleRequest {
+
   private Long teamId;
   private Long categoryId;
-
   @NotBlank(message = "일정 제목을 입력해주세요.")
   @Size(min = 1, max = 10, message = "일정 제목은 1자 이상, 10자 이하여야 합니다.")
   private String title;
   private String content;
-
   @JsonFormat(pattern = "yyyy-MM-dd HH:mm")
   private LocalDateTime startDt;
-
   @JsonFormat(pattern = "yyyy-MM-dd HH:mm")
   private LocalDateTime endDt;
-
   private String place;
   private RepeatCycle repeatCycle;
-  private String month;
-  private int day;
-  private String dayOfWeek;
   private String color;
   private List<Long> teamParticipantsIds;
 }

--- a/backend/src/main/java/com/api/backend/schedule/data/dto/ScheduleResponse.java
+++ b/backend/src/main/java/com/api/backend/schedule/data/dto/ScheduleResponse.java
@@ -19,9 +19,10 @@ import java.util.List;
 @Builder
 @AllArgsConstructor
 public class ScheduleResponse {
-  private String scheduleType;
+
   private Long scheduleId;
-  private Long categoryId;
+  private String scheduleType;
+  private String categoryName;
   @JsonFormat(pattern = "yyyy-MM-dd HH:mm")
   private LocalDateTime startDt;
   @JsonFormat(pattern = "yyyy-MM-dd HH:mm")
@@ -29,6 +30,7 @@ public class ScheduleResponse {
   private String title;
   private String content;
   private String place;
+  private String color;
   private RepeatCycle repeatCycle;
   private String month;
   private int day;
@@ -39,9 +41,9 @@ public class ScheduleResponse {
 
   public static ScheduleResponse from(RepeatScheduleResponse repeatScheduleResponse) {
     return ScheduleResponse.builder()
-        .scheduleType("반복 일정")
         .scheduleId(repeatScheduleResponse.getScheduleId())
-        .categoryId(repeatScheduleResponse.getCategoryId())
+        .scheduleType("반복 일정")
+        .categoryName(repeatScheduleResponse.getCategoryName())
         .startDt(repeatScheduleResponse.getStartDt())
         .endDt(repeatScheduleResponse.getEndDt())
         .title(repeatScheduleResponse.getTitle())
@@ -59,9 +61,10 @@ public class ScheduleResponse {
 
   public static ScheduleResponse from(SimpleScheduleResponse simpleScheduleResponse) {
     return ScheduleResponse.builder()
-        .scheduleType("단순 일정")
         .scheduleId(simpleScheduleResponse.getScheduleId())
-        .categoryId(simpleScheduleResponse.getCategoryId())
+        .scheduleType("단순 일정")
+        .categoryName(simpleScheduleResponse.getCategoryName())
+        .scheduleId(simpleScheduleResponse.getScheduleId())
         .startDt(simpleScheduleResponse.getStartDt())
         .endDt(simpleScheduleResponse.getEndDt())
         .title(simpleScheduleResponse.getTitle())

--- a/backend/src/main/java/com/api/backend/schedule/data/dto/ScheduleTypeConverterResponse.java
+++ b/backend/src/main/java/com/api/backend/schedule/data/dto/ScheduleTypeConverterResponse.java
@@ -14,7 +14,7 @@ import lombok.Getter;
 @Getter
 @Builder
 @AllArgsConstructor
-public class ScheduleEditResponse {
+public class ScheduleTypeConverterResponse {
   private Long scheduleId;
   private String categoryName;
   private String title;
@@ -24,38 +24,51 @@ public class ScheduleEditResponse {
   @JsonFormat(pattern = "yyyy-MM-dd HH:mm")
   private LocalDateTime endDt;
   private String place;
-  private boolean isRepeat;
+  private String color;
   private RepeatCycle repeatCycle;
+  private String month;
+  private int day;
+  private String dayOfWeek;
   private List<Long> teamParticipantsIds;
   private List<String> teamParticipantsNames;
   private List<TeamRole> teamRoles;
   private boolean isConverted;
 
-  public static ScheduleEditResponse from(SimpleSchedule simpleSchedule) {
-    return ScheduleEditResponse.builder()
+  public static ScheduleTypeConverterResponse from(SimpleSchedule simpleSchedule) {
+    return ScheduleTypeConverterResponse.builder()
+        .scheduleId(simpleSchedule.getSimpleScheduleId())
         .categoryName(simpleSchedule.getScheduleCategory().getCategoryName())
         .startDt(simpleSchedule.getStartDt())
         .endDt(simpleSchedule.getEndDt())
         .title(simpleSchedule.getTitle())
         .content(simpleSchedule.getContent())
         .place(simpleSchedule.getPlace())
+        .color(simpleSchedule.getColor())
         .teamParticipantsIds(ScheduleResponse.getTeamParticipantsIdsFromSchedules(simpleSchedule.getTeamParticipantsSchedules()))
         .teamParticipantsNames(ScheduleResponse.getTeamParticipantsNameFromSchedules(simpleSchedule.getTeamParticipantsSchedules()))
         .teamRoles(ScheduleResponse.getTeamParticipantsRoleFromSchedules(simpleSchedule.getTeamParticipantsSchedules()))
+        .isConverted(true)
         .build();
   }
 
-  public static ScheduleEditResponse from(RepeatSchedule repeatSchedule) {
-    return ScheduleEditResponse.builder()
+  public static ScheduleTypeConverterResponse from(RepeatSchedule repeatSchedule) {
+    return ScheduleTypeConverterResponse.builder()
+        .scheduleId(repeatSchedule.getRepeatScheduleId())
         .categoryName(repeatSchedule.getScheduleCategory().getCategoryName())
         .startDt(repeatSchedule.getStartDt())
         .endDt(repeatSchedule.getEndDt())
         .title(repeatSchedule.getTitle())
         .content(repeatSchedule.getContent())
         .place(repeatSchedule.getPlace())
+        .color(repeatSchedule.getColor())
+        .repeatCycle(repeatSchedule.getRepeatCycle())
+        .month(repeatSchedule.getMonth())
+        .day(repeatSchedule.getDay())
+        .dayOfWeek(repeatSchedule.getDayOfWeek())
         .teamParticipantsIds(ScheduleResponse.getTeamParticipantsIdsFromSchedules(repeatSchedule.getTeamParticipantsSchedules()))
         .teamParticipantsNames(ScheduleResponse.getTeamParticipantsNameFromSchedules(repeatSchedule.getTeamParticipantsSchedules()))
         .teamRoles(ScheduleResponse.getTeamParticipantsRoleFromSchedules(repeatSchedule.getTeamParticipantsSchedules()))
+        .isConverted(true)
         .build();
   }
 

--- a/backend/src/main/java/com/api/backend/schedule/data/dto/SimpleScheduleInfoEditRequest.java
+++ b/backend/src/main/java/com/api/backend/schedule/data/dto/SimpleScheduleInfoEditRequest.java
@@ -1,7 +1,6 @@
 package com.api.backend.schedule.data.dto;
 
 import com.api.backend.schedule.customValidAnnotation.StartAndEndDtCheck;
-import com.api.backend.schedule.data.type.RepeatCycle;
 import com.fasterxml.jackson.annotation.JsonFormat;
 import java.time.LocalDateTime;
 import java.util.List;
@@ -9,12 +8,13 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 
+//단순 일정 정보만 수정
 @Getter
 @AllArgsConstructor
 @Builder
 @StartAndEndDtCheck(scheduleStart = "startDt", scheduleEnd = "endDt")
-//단순일정  -> 단순일정
 public class SimpleScheduleInfoEditRequest {
+
   private Long simpleScheduleId;
   private Long teamId;
   private Long categoryId;
@@ -25,7 +25,6 @@ public class SimpleScheduleInfoEditRequest {
   @JsonFormat(pattern = "yyyy-MM-dd HH:mm")
   private LocalDateTime endDt;
   private String place;
-  private RepeatCycle repeatCycle;
   private List<Long> teamParticipantsIds;
   private String color;
 }

--- a/backend/src/main/java/com/api/backend/schedule/data/dto/SimpleScheduleInfoEditResponse.java
+++ b/backend/src/main/java/com/api/backend/schedule/data/dto/SimpleScheduleInfoEditResponse.java
@@ -1,0 +1,87 @@
+package com.api.backend.schedule.data.dto;
+
+import com.api.backend.schedule.data.entity.SimpleSchedule;
+import com.api.backend.schedule.data.entity.TeamParticipantsSchedule;
+import com.api.backend.team.data.type.TeamRole;
+import com.fasterxml.jackson.annotation.JsonFormat;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+@AllArgsConstructor
+public class SimpleScheduleInfoEditResponse {
+
+  private Long scheduleId;
+  private String scheduleType;
+  private String categoryName;
+  @JsonFormat(pattern = "yyyy-MM-dd HH:mm")
+  private LocalDateTime startDt;
+  @JsonFormat(pattern = "yyyy-MM-dd HH:mm")
+  private LocalDateTime endDt;
+  private String title;
+  private String content;
+  private String place;
+  private String color;
+  private List<Long> teamParticipantsIds;
+  private List<String> teamParticipantsNames;
+  private List<TeamRole> teamRoles;
+
+  public static SimpleScheduleInfoEditResponse from(SimpleSchedule simpleSchedule) {
+    return SimpleScheduleInfoEditResponse.builder()
+        .scheduleId(simpleSchedule.getSimpleScheduleId())
+        .scheduleType("단순 일정")
+        .categoryName(simpleSchedule.getScheduleCategory().getCategoryName())
+        .startDt(simpleSchedule.getStartDt())
+        .endDt(simpleSchedule.getEndDt())
+        .title(simpleSchedule.getTitle())
+        .content(simpleSchedule.getContent())
+        .place(simpleSchedule.getPlace())
+        .color(simpleSchedule.getColor())
+        .teamParticipantsIds(
+            getTeamParticipantsIdsFromSchedules(simpleSchedule.getTeamParticipantsSchedules()))
+        .teamParticipantsNames(
+            getTeamParticipantsNameFromSchedules(simpleSchedule.getTeamParticipantsSchedules()))
+        .teamRoles(
+            getTeamParticipantsRoleFromSchedules(simpleSchedule.getTeamParticipantsSchedules()))
+        .build();
+  }
+
+  public static List<Long> getTeamParticipantsIdsFromSchedules(
+      List<TeamParticipantsSchedule> teamParticipantsSchedules) {
+    List<Long> teamParticipantsIds = new ArrayList<>();
+    if (teamParticipantsSchedules != null) {
+      for (TeamParticipantsSchedule teamParticipantsSchedule : teamParticipantsSchedules) {
+        teamParticipantsIds.add(
+            teamParticipantsSchedule.getTeamParticipants().getTeamParticipantsId());
+      }
+    }
+    return teamParticipantsIds;
+  }
+
+  public static List<String> getTeamParticipantsNameFromSchedules(
+      List<TeamParticipantsSchedule> teamParticipantsSchedules) {
+    List<String> teamParticipantsNames = new ArrayList<>();
+    if (teamParticipantsSchedules != null) {
+      for (TeamParticipantsSchedule teamParticipantsSchedule : teamParticipantsSchedules) {
+        teamParticipantsNames.add(teamParticipantsSchedule.getTeamParticipants().getTeamNickName());
+      }
+    }
+    return teamParticipantsNames;
+  }
+
+  public static List<TeamRole> getTeamParticipantsRoleFromSchedules(
+      List<TeamParticipantsSchedule> teamParticipantsSchedules) {
+    List<TeamRole> teamParticipantsRoles = new ArrayList<>();
+    if (teamParticipantsSchedules != null) {
+      for (TeamParticipantsSchedule teamParticipantsSchedule : teamParticipantsSchedules) {
+        teamParticipantsRoles.add(teamParticipantsSchedule.getTeamParticipants().getTeamRole());
+      }
+    }
+    return teamParticipantsRoles;
+  }
+}

--- a/backend/src/main/java/com/api/backend/schedule/data/dto/SimpleScheduleResponse.java
+++ b/backend/src/main/java/com/api/backend/schedule/data/dto/SimpleScheduleResponse.java
@@ -15,9 +15,10 @@ import lombok.Getter;
 @Builder
 @AllArgsConstructor
 public class SimpleScheduleResponse {
-  private String scheduleType;
+
   private Long scheduleId;
-  private Long categoryId;
+  private String scheduleType;
+  private String categoryName;
   @JsonFormat(pattern = "yyyy-MM-dd HH:mm")
   private LocalDateTime startDt;
   @JsonFormat(pattern = "yyyy-MM-dd HH:mm")
@@ -25,6 +26,7 @@ public class SimpleScheduleResponse {
   private String title;
   private String content;
   private String place;
+  private String color;
   private List<Long> teamParticipantsIds;
   private List<String> teamParticipantsNames;
   private List<TeamRole> teamRoles;
@@ -32,8 +34,7 @@ public class SimpleScheduleResponse {
   public static SimpleScheduleResponse from(SimpleSchedule simpleSchedule) {
     return SimpleScheduleResponse.builder()
         .scheduleType("단순 일정")
-        .scheduleId(simpleSchedule.getSimpleScheduleId())
-        .categoryId(simpleSchedule.getScheduleCategory().getScheduleCategoryId())
+        .categoryName(simpleSchedule.getScheduleCategory().getCategoryName())
         .startDt(simpleSchedule.getStartDt())
         .endDt(simpleSchedule.getEndDt())
         .title(simpleSchedule.getTitle())
@@ -43,9 +44,11 @@ public class SimpleScheduleResponse {
             getTeamParticipantsIdsFromSchedules(simpleSchedule.getTeamParticipantsSchedules()))
         .teamParticipantsNames(
             getTeamParticipantsNameFromSchedules(simpleSchedule.getTeamParticipantsSchedules()))
-        .teamRoles(getTeamParticipantsRoleFromSchedules(simpleSchedule.getTeamParticipantsSchedules()))
+        .teamRoles(
+            getTeamParticipantsRoleFromSchedules(simpleSchedule.getTeamParticipantsSchedules()))
         .build();
   }
+
   public static List<Long> getTeamParticipantsIdsFromSchedules(
       List<TeamParticipantsSchedule> teamParticipantsSchedules) {
     List<Long> teamParticipantsIds = new ArrayList<>();

--- a/backend/src/main/java/com/api/backend/schedule/data/dto/SimpleToRepeatScheduleEditRequest.java
+++ b/backend/src/main/java/com/api/backend/schedule/data/dto/SimpleToRepeatScheduleEditRequest.java
@@ -2,7 +2,6 @@ package com.api.backend.schedule.data.dto;
 
 
 import com.api.backend.schedule.customValidAnnotation.StartAndEndDtCheck;
-import com.api.backend.schedule.data.type.EditOption;
 import com.api.backend.schedule.data.type.RepeatCycle;
 import com.fasterxml.jackson.annotation.JsonFormat;
 import java.time.LocalDateTime;
@@ -11,27 +10,24 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 
+//단순 일정 -> 반복 일정
 @Getter
 @AllArgsConstructor
 @Builder
 @StartAndEndDtCheck(scheduleStart = "startDt", scheduleEnd = "endDt")
 public class SimpleToRepeatScheduleEditRequest {
+
   private Long simpleScheduleId;
   private Long teamId;
   private Long categoryId;
   private String title;
   private String content;
-
   @JsonFormat(pattern = "yyyy-MM-dd HH:mm")
   private LocalDateTime startDt;
-
   @JsonFormat(pattern = "yyyy-MM-dd HH:mm")
   private LocalDateTime endDt;
-
   private String place;
   private RepeatCycle repeatCycle;
   private List<Long> teamParticipantsIds;
   private String color;
-  private EditOption editOption;
-  private boolean isConverted;
 }

--- a/backend/src/main/java/com/api/backend/schedule/service/ScheduleService.java
+++ b/backend/src/main/java/com/api/backend/schedule/service/ScheduleService.java
@@ -14,8 +14,10 @@ import com.api.backend.global.exception.CustomException;
 import com.api.backend.global.exception.type.ErrorCode;
 import com.api.backend.schedule.data.dto.AllSchedulesMonthlyView;
 import com.api.backend.schedule.data.dto.RepeatScheduleInfoEditRequest;
+import com.api.backend.schedule.data.dto.RepeatToSimpleScheduleEditRequest;
 import com.api.backend.schedule.data.dto.ScheduleRequest;
 import com.api.backend.schedule.data.dto.SimpleScheduleInfoEditRequest;
+import com.api.backend.schedule.data.dto.SimpleToRepeatScheduleEditRequest;
 import com.api.backend.schedule.data.entity.RepeatSchedule;
 import com.api.backend.schedule.data.entity.SimpleSchedule;
 import com.api.backend.schedule.data.entity.TeamParticipantsSchedule;
@@ -115,6 +117,35 @@ public class ScheduleService {
 
     updatedSimpleSchedule.setTeamParticipantsSchedules(teamParticipantsSchedules);
     return simpleScheduleRepository.save(updatedSimpleSchedule);
+  }
+
+
+  @Transactional
+  public SimpleSchedule convertRepeatToSimpleSchedule(RepeatToSimpleScheduleEditRequest editRequest, Principal principal) {
+    Team team = findTeamOrElseThrow(editRequest.getTeamId());
+    ScheduleCategory category = findScheduleCategoryOrElseThrow(editRequest.getCategoryId());
+    List<Long> teamParticipantsIds = editRequest.getTeamParticipantsIds();
+    validateSameTeamOrElsThrow(teamParticipantsIds, team.getTeamId());
+    RepeatSchedule repeatSchedule = findRepeatScheduleOrElseThrow(editRequest.getRepeatScheduleId());
+
+    SimpleSchedule simpleSchedule = SimpleSchedule.builder()
+        .team(team)
+        .scheduleCategory(category)
+        .title(editRequest.getTitle())
+        .content(editRequest.getContent())
+        .startDt(editRequest.getStartDt())
+        .endDt(editRequest.getEndDt())
+        .place(editRequest.getPlace())
+        .color(editRequest.getColor())
+        .build();
+
+    List<TeamParticipantsSchedule> teamParticipantsSchedules = buildTeamParticipantsSchedulesBySimpleSchedule(
+        simpleSchedule, editRequest.getTeamParticipantsIds()
+    );
+
+    simpleSchedule.setTeamParticipantsSchedules(teamParticipantsSchedules);
+    repeatScheduleRepository.delete(repeatSchedule);
+    return simpleScheduleRepository.save(simpleSchedule);
   }
 
   @Transactional


### PR DESCRIPTION
### 변경 내용
<!-- 여기에 변경한 내용을 명시해주세요. -->

AS-IS
- Request, Response DTO 에 불필요한 데이터가 들어있거나 필요한 데이터 누락
- 수정 시에 ScheduleEditResponse 하나로만 응답

TO-BE
- Request, Response 누락되거나 불필요한 요청 및 응답 데이터 수정
- 정보만 수정시엔 각 일정 유형에 맞는 DTO로 응답
- 단순 일정 -> 반복 일정 , 반복 일정 -> 단순 일정 변경 가능

### 테스트
<!-- 본 변경사항이 테스트가 되었는지 기술해주세요 --> 
* [ ] 테스트 코드
* [x] API 테스트

### 관련 이슈
<!-- 이 PR과 관련된 이슈 번호를 명시해주세요. 예: #123 -->

### 변경 사항 검토
* [x] api 문서 업데이트
Notion에 일정 API 수정했습니다. 

### 특이 사항
<!-- 리뷰어에게 특별히 주의해야 할 사항이나 테스트할 때 필요한 추가 정보를 여기에 적어주세요. -->
- 추후 코드 리팩토링 단계에서 중복되는 코드(아래 첨부 사진)를 수정할 예정입니다. 
- DTO나 서비스에 주석처리 되어있는 부분 역시 추후 리팩토링 단계에서 삭제할 예정입니다

### 스크린샷 (선택 사항)
<!-- 필요한 경우 변경 내용에 대한 스크린샷을 첨부하세요. -->
![image](https://github.com/100backfro/teammate/assets/122286693/33682f56-8848-42d6-a9c0-cf3b8f104bad)
