### PR TITLE
Feat/myteam page

### DIFF
--- a/frontend/src/components/Home/HomeContent.tsx
+++ b/frontend/src/components/Home/HomeContent.tsx
@@ -4,20 +4,23 @@ import axiosInstance from "../../axios";
 import { useNavigate } from "react-router-dom";
 import styled from "styled-components";
 import {
-  useSearchState,
+  searchState,
   userTeamsState,
   accessTokenState,
   isAuthenticatedState,
 } from "../../state/authState";
 import { Team } from "../../interface/interface.ts";
 
+const ITEMS_PER_PAGE = 10;
+
 const HomeContent = () => {
   const [userTeams, setUserTeams] = useRecoilState<Team[]>(userTeamsState);
-  const { search } = useSearchState();
+  const search = useRecoilValue(searchState);
   const [error, setError] = useState<string | null>(null);
   const accessToken = useRecoilValue(accessTokenState);
   const navigate = useNavigate();
   const isAuthenticated = useRecoilValue(isAuthenticatedState);
+  const [currentPage, setCurrentPage] = useState(1);
 
   useEffect(() => {
     const fetchLoggedInUserId = async () => {
@@ -27,9 +30,7 @@ const HomeContent = () => {
           return;
         }
         const teamListResponse = await axiosInstance.get("/team/list");
-        // Recoil 상태 업데이트
         setUserTeams(teamListResponse.data);
-        // localStorage에 저장
         window.sessionStorage.setItem(
           `teamList_${accessToken}`,
           JSON.stringify(teamListResponse.data),
@@ -52,28 +53,72 @@ const HomeContent = () => {
     return null;
   }
 
-  const filteredTeamList = userTeams.filter((team) =>
-    team.name.toLowerCase().includes(search.toLowerCase()),
+  const filteredTeamList = userTeams
+    .filter((team) => team.name.toLowerCase().includes(search.toLowerCase()))
+    .filter((team) => {
+      return (
+        team.restorationDt === null ||
+        team.teamRole === "READER" ||
+        (team.teamRole === "MATE" && team.restorationDt === null)
+      );
+    });
+
+  const indexOfLastTeam = currentPage * ITEMS_PER_PAGE;
+  const indexOfFirstTeam = indexOfLastTeam - ITEMS_PER_PAGE;
+  const currentTeams = filteredTeamList.slice(
+    indexOfFirstTeam,
+    indexOfLastTeam,
   );
+
+  const paginate = (pageNumber: number) => {
+    setCurrentPage(pageNumber);
+  };
+
+  const handleRestoration = async (teamId: number) => {
+    try {
+      await axiosInstance.patch(`/team/{teamId}/restore?restoreDt=2023-01-01`);
+      const updatedTeamList = await axiosInstance.get("/team/list");
+      setUserTeams(updatedTeamList.data);
+    } catch (error: any) {
+      console.error("팀 복구 중 에러 발생:", error);
+    }
+  };
 
   return (
     <TeamListContainer>
-      {filteredTeamList.map((team, index) => (
+      {currentTeams.map((team, index) => (
         <TeamItem key={index}>
           <TeamCard
-            onClick={() =>
+            onClick={() => {
+              if (team.restorationDt !== null) {
+                return;
+              }
               navigate(`/team/${team.teamId}`, {
                 state: { team },
-              })
-            }
+              });
+            }}
           >
             <TeamName>{team.name}</TeamName>
             {team.profileUrl && (
               <TeamImage src={team.profileUrl} alt={`${team.name} 이미지`} />
             )}
+            {team.restorationDt !== null && (
+              <RestorationButton onClick={() => handleRestoration(team.teamId)}>
+                복구
+              </RestorationButton>
+            )}
           </TeamCard>
         </TeamItem>
       ))}
+      <Pagination>
+        {Array.from({
+          length: Math.ceil(filteredTeamList.length / ITEMS_PER_PAGE),
+        }).map((_, index) => (
+          <PageNumber key={index} onClick={() => paginate(index + 1)}>
+            {index + 1}
+          </PageNumber>
+        ))}
+      </Pagination>
     </TeamListContainer>
   );
 };
@@ -122,4 +167,39 @@ const TeamImage = styled.img`
   margin-bottom: 8px;
   margin: 0 auto;
   object-fit: cover;
+`;
+
+const Pagination = styled.div`
+  display: flex;
+  justify-content: center;
+  width: 100%;
+  height: 30px;
+`;
+
+const PageNumber = styled.div`
+  width: 30px;
+  height: 30px;
+  cursor: pointer;
+  color: #333333;
+  border-radius: 50px;
+  text-align: center;
+  padding: 4px;
+
+  &:hover {
+    background-color: #a3cca3;
+  }
+`;
+
+const RestorationButton = styled.button`
+  background-color: #a3cca3;
+  color: white;
+  border: none;
+  padding: 6px 12px;
+  border-radius: 4px;
+  margin-top: 8px;
+  cursor: pointer;
+
+  &:hover {
+    background-color: #cccccc;
+  }
 `;

--- a/frontend/src/components/Home/HomeContent.tsx
+++ b/frontend/src/components/Home/HomeContent.tsx
@@ -58,7 +58,7 @@ const HomeContent = () => {
     .filter((team) => {
       return (
         team.restorationDt === null ||
-        team.teamRole === "READER" ||
+        team.teamRole === "LEADER" ||
         (team.teamRole === "MATE" && team.restorationDt === null)
       );
     });

--- a/frontend/src/components/Home/HomeContent.tsx
+++ b/frontend/src/components/Home/HomeContent.tsx
@@ -76,9 +76,10 @@ const HomeContent = () => {
 
   const handleRestoration = async (teamId: number) => {
     try {
-      await axiosInstance.patch(`/team/{teamId}/restore?restoreDt=2023-01-01`);
+      await axiosInstance.patch(`/team/${teamId}/restore?restoreDt=2023-01-01`);
       const updatedTeamList = await axiosInstance.get("/team/list");
       setUserTeams(updatedTeamList.data);
+      alert("복구가 완료되었습니다.");
     } catch (error: any) {
       console.error("팀 복구 중 에러 발생:", error);
     }

--- a/frontend/src/components/Home/HomeCreateTeamBtn.tsx
+++ b/frontend/src/components/Home/HomeCreateTeamBtn.tsx
@@ -1,12 +1,68 @@
 import { Link } from "react-router-dom";
 import styled from "styled-components";
+import { useState } from "react";
+import axiosInstance from "../../axios";
 
 export default function HomeCreateTeamBtn() {
+  const [inviteCode, setInviteCode] = useState("");
+
+  const handleInputInviteCode = (event: any) => {
+    setInviteCode(event.target.value);
+  };
+
+  const handleCreateTeam = () => {
+    if (!inviteCode) {
+      alert("초대 코드를 입력하세요.");
+      return;
+    }
+    axiosInstance
+      .get(`/team/${inviteCode}`)
+      .then((response) => {
+        console.log(response.data);
+        alert("팀에 참가되었습니다.");
+        window.location.reload();
+      })
+      .catch((error) => {
+        console.error("API call error:", error);
+        if (error.response) {
+          switch (error.response.status) {
+            case 401:
+              alert("토큰 값이 유효하지 않습니다.");
+              break;
+            case 404:
+              alert("팀이 해체되었습니다.");
+              break;
+            case 409:
+              alert("팀에 이미 참가한 경우입니다.");
+              break;
+            case 422:
+              alert("회원이 존재하지 않습니다.");
+              break;
+            case 429:
+              alert("팀 인원 제한에 걸렸습니다.");
+              break;
+            default:
+              alert("API 호출 중 오류가 발생했습니다.");
+              break;
+          }
+        } else {
+          alert("이미 참가된 팀입니다.");
+        }
+      });
+  };
+
   return (
     <CenteredContainer>
       <Link to="/teamInfo">
         <CreateTeamButton>+ 팀 생성하기</CreateTeamButton>
       </Link>
+      <TeamNameInput
+        type="text"
+        placeholder="초대코드를 입력하세요"
+        value={inviteCode}
+        onChange={handleInputInviteCode}
+      />
+      <CreateTeamButton onClick={handleCreateTeam}>참가</CreateTeamButton>
     </CenteredContainer>
   );
 }
@@ -33,4 +89,14 @@ const CreateTeamButton = styled.button`
   &:hover {
     background-color: #cccccc;
   }
+`;
+
+const TeamNameInput = styled.input`
+  margin-top: 20px;
+  margin-right: 5px;
+  margin-left: 30px;
+  padding: 8px;
+  border: 1px solid #cccccc;
+  border-radius: 20px;
+  outline: none;
 `;

--- a/frontend/src/components/Home/HomeSearchBar.tsx
+++ b/frontend/src/components/Home/HomeSearchBar.tsx
@@ -49,9 +49,9 @@ export default function HomeSearchBar() {
               >
                 <path
                   stroke="currentColor"
-                  stroke-linecap="round"
-                  stroke-linejoin="round"
-                  stroke-width="2"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  strokeWidth="2"
                   d="m19 19-4-4m0-7A7 7 0 1 1 1 8a7 7 0 0 1 14 0Z"
                 />
               </svg>

--- a/frontend/src/components/Home/HomeSearchBar.tsx
+++ b/frontend/src/components/Home/HomeSearchBar.tsx
@@ -2,14 +2,17 @@ import { useState } from "react";
 import { useSearchState } from "../../state/authState";
 import styled from "styled-components";
 
-export default function HomeSearchBar() {
-  const { search, setSearch, handleSearch } = useSearchState();
+interface HomeSearchBarProps {
+  onSearch: (value: string) => void;
+}
+
+export default function HomeSearchBar({ onSearch }: HomeSearchBarProps) {
+  const { search, setSearch } = useSearchState();
   const [isPlaceholderHidden, setPlaceholderHidden] = useState(false);
 
-  const handleSearchSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
+  const handleSearchSubmit = async (e: any) => {
     e.preventDefault();
-
-    await handleSearch(search);
+    onSearch(search);
   };
 
   const handleClick = () => {
@@ -68,12 +71,12 @@ export default function HomeSearchBar() {
               placeholder="팀 명을 검색하세요"
               required
             />
-            <button
+            <Button
               type="submit"
               className="text-white absolute end-2.5 bottom-2.5 bg-green-700 hover:bg-blue-800 focus:ring-4 focus:outline-none focus:ring-blue-300 font-medium rounded-lg text-sm px-4 py-2"
             >
               Search
-            </button>
+            </Button>
           </div>
         </form>
       </SearchBarContainer>
@@ -89,26 +92,8 @@ const SearchBarContainer = styled.div`
   width: 1000px;
   height: 50px;
   justify-content: center;
+`;
 
-  //   input {
-  //     padding: 8px;
-  //     border: 2px solid #ccc;
-  //     border-radius: 50px;
-  //     flex: 1;
-  //     height: 100%;
-  //     outline: none;
-  //     position: relative;
-  //     text-align: Center;
-  //     background: white;
-  //   }
-
-  //   .search-icon {
-  //     width: 16px;
-  //     height: 16px;
-  //     position: absolute;
-  //     right: 20px;
-  //     top: 50%;
-  //     transform: translateY(-50%);
-  //     cursor: pointer;
-  //   }
+const Button = styled.button`
+  background: #a3cca3;
 `;

--- a/frontend/src/components/Join/SignUp.tsx
+++ b/frontend/src/components/Join/SignUp.tsx
@@ -270,10 +270,27 @@ const SignUp: React.FC<SignUpProps> = () => {
         <button onClick={handleSignUp}>회원 가입</button>
       </StyledFormItem>
 
-      {signUpMessage && <p style={{ color: "red" }}>{signUpMessage}</p>}
+      {signUpMessage && (
+        <p
+          style={{
+            color: "red",
+            textAlign: "center",
+            marginTop: "10px",
+          }}
+        >
+          {signUpMessage}
+        </p>
+      )}
       {isModalOpen && (
-        <div className="modal">
-          <p>아이디로 이메일 인증을 보냈습니다. 확인해주세요.</p>
+        <div>
+          <p
+            style={{
+              textAlign: "center",
+              marginTop: "10px",
+            }}
+          >
+            아이디로 이메일 인증을 보냈습니다.{" "}
+          </p>
           <Button onClick={handleModalConfirm}>확인</Button>
         </div>
       )}

--- a/frontend/src/components/Join/SignUpStyled.tsx
+++ b/frontend/src/components/Join/SignUpStyled.tsx
@@ -3,13 +3,14 @@ import styled from "styled-components";
 export const StyledContainer = styled.div`
   color: #333333;
   padding: 20px;
-  max-width: 300px;
+  max-width: 400px;
   margin: auto;
 `;
 
 export const StyledFormItem = styled.div`
   margin: 5px 0 5px 0;
   display: flex;
+  width: 350px;
 
   label {
     margin-right: 60px;
@@ -40,17 +41,19 @@ export const StyledFormItem = styled.div`
       background-color: #cccccc;
     }
   }
+  span {
+    margin-left: 30px;
+  }
 `;
 
-export const Button = styled.div`
+export const Button = styled.button`
   button {
     flex: 1;
-    margin-left: 10px;
     padding: 8px;
     background-color: #a3cca3;
     color: #333333;
     cursor: pointer;
-
+    textAlign: "center",
     &:hover {
       background-color: #cccccc;
     }

--- a/frontend/src/components/Modal.tsx
+++ b/frontend/src/components/Modal.tsx
@@ -25,6 +25,9 @@ const ModalContent = styled.div`
   padding: 20px;
   border-radius: 8px;
   box-shadow: 0 0 10px rgba(0, 0, 0, 0.5);
+  input {
+    border: 1px solid #cccccc;
+  }
 `;
 
 const CloseButton = styled.button`

--- a/frontend/src/components/ProfilePage/TeamLeader.tsx
+++ b/frontend/src/components/ProfilePage/TeamLeader.tsx
@@ -216,7 +216,9 @@ export default function TeamLeader() {
           teamId: team?.teamId,
           teamName: team?.name,
         });
-        alert("팀이 삭제되었습니다.");
+        alert(
+          "팀이 삭제되었습니다. 복구는 30일 이내로 가능하며 30일 뒤에는 자동으로 팀이 해체됩니다.",
+        );
         console.log("팀 삭제 응답:", response.data);
         navigate("/homeView");
       } else {
@@ -235,8 +237,7 @@ export default function TeamLeader() {
       try {
         const response = await axiosInstance.get(`/team/${teamId}/code`);
         const teamCode = response.data;
-        // console.log("초대코드", teamCode);
-        const codeUrl = `http://118.67.128.124:8080/team/${teamCode}`;
+        const codeUrl = `${teamCode}`;
         setCodeUrl(codeUrl);
         // await axiosInstance.post(codeUrl);
       } catch (error) {

--- a/frontend/src/components/ProfilePage/TeamLeader.tsx
+++ b/frontend/src/components/ProfilePage/TeamLeader.tsx
@@ -177,7 +177,7 @@ export default function TeamLeader() {
         const response = await axiosInstance.patch(
           `/team/${teamId}/participant/${selectedParticipant.teamParticipantsId}`,
           {
-            teamRole: "READER",
+            teamRole: "LEADER",
           },
         );
         alert("팀장이 변경되었습니다.");
@@ -324,18 +324,18 @@ export default function TeamLeader() {
               <option
                 value={
                   teamParticipants.find(
-                    (participant) => participant.teamRole === "READER",
+                    (participant) => participant.teamRole === "LEADER",
                   )?.teamNickName
                 }
               >
                 {
                   teamParticipants.find(
-                    (participant) => participant.teamRole === "READER",
+                    (participant) => participant.teamRole === "LEADER",
                   )?.teamNickName
                 }
               </option>
               {teamParticipants
-                .filter((participant) => participant.teamRole !== "READER")
+                .filter((participant) => participant.teamRole !== "LEADER")
                 .map((participant, index) => (
                   <option key={index} value={participant.teamNickName}>
                     {participant.teamNickName}

--- a/frontend/src/components/ProfilePage/TeamMembers.tsx
+++ b/frontend/src/components/ProfilePage/TeamMembers.tsx
@@ -139,8 +139,8 @@ const TeamInfoContainer = styled.div`
 `;
 
 const TeamImage = styled.img`
-  max-width: 100px;
-  max-height: 100px;
+  max-width: 150px;
+  max-height: 150px;
   border-radius: 50%;
 `;
 

--- a/frontend/src/components/ProfilePage/TeamMembers.tsx
+++ b/frontend/src/components/ProfilePage/TeamMembers.tsx
@@ -54,9 +54,9 @@ const TeamMembers = () => {
           member.name.toLowerCase().includes(searchTeam.toLowerCase()),
         )
         .sort((a, b) => {
-          if (a.role === "READER" && b.role !== "READER") {
+          if (a.role === "LEADER" && b.role !== "LEADER") {
             return -1;
-          } else if (a.role !== "READER" && b.role === "READER") {
+          } else if (a.role !== "LEADER" && b.role === "LEADER") {
             return 1;
           } else {
             return a.name.localeCompare(b.name);
@@ -102,9 +102,9 @@ const TeamMembers = () => {
                   key={member.id}
                   type="text"
                   value={`${member.name} ${
-                    member.role === "READER" ? "(팀장)" : ""
+                    member.role === "LEADER" ? "(팀장)" : ""
                   }`}
-                  style={getMemberStyle(member.role === "READER")}
+                  style={getMemberStyle(member.role === "LEADER")}
                 />
               ))}
             </MemberContainer>

--- a/frontend/src/components/alarm/AlarmModal.tsx
+++ b/frontend/src/components/alarm/AlarmModal.tsx
@@ -9,14 +9,15 @@ interface AlarmModalProps {
 // 가짜 데이터
 const fakePersonalAlarmProps = {
   content: "알람 내용",
-  date: "2023-12-17", // 적절한 날짜로 대체
+  date: "2023-12-17",
   onDelete: () => {
-    // 삭제 로직 구현
+    console.log("개인 알람이 삭제되었습니다.");
   },
 };
 
 const AlarmModal: React.FC<AlarmModalProps> = ({ closeModal }) => {
   const [activeTab, setActiveTab] = useState<"personal" | "team">("personal");
+  const [alarmList, setAlarmList] = useState([fakePersonalAlarmProps]);
 
   const switchTab = (tab: "personal" | "team") => {
     setActiveTab(tab);
@@ -24,6 +25,16 @@ const AlarmModal: React.FC<AlarmModalProps> = ({ closeModal }) => {
 
   const handleModalClick = (e: React.MouseEvent) => {
     e.stopPropagation();
+  };
+
+  const handleDeletePersonalAlarm = () => {
+    setAlarmList((prevList) => {
+      const updatedList = prevList.filter(
+        (alarm) => alarm !== fakePersonalAlarmProps,
+      );
+      console.log("개인 알람이 삭제되었습니다.");
+      return updatedList;
+    });
   };
 
   return (
@@ -45,7 +56,10 @@ const AlarmModal: React.FC<AlarmModalProps> = ({ closeModal }) => {
           </TabButton>
         </TabButtons>
         {activeTab === "personal" ? (
-          <PersonalAlarm {...fakePersonalAlarmProps} />
+          <PersonalAlarm
+            {...fakePersonalAlarmProps}
+            onDelete={handleDeletePersonalAlarm}
+          />
         ) : (
           <TeamAlarm {...fakePersonalAlarmProps} />
         )}

--- a/frontend/src/components/alarm/PersonalAlarm.tsx
+++ b/frontend/src/components/alarm/PersonalAlarm.tsx
@@ -7,11 +7,7 @@ interface PersonalAlarmProps {
   onDelete: () => void;
 }
 
-const PersonalAlarm: React.FC<PersonalAlarmProps> = ({
-  content,
-  date,
-  onDelete,
-}) => {
+const PersonalAlarm: React.FC<PersonalAlarmProps> = ({ content, onDelete }) => {
   const today = new Date();
   const formattedDate = `${today.getFullYear()}-${
     today.getMonth() + 1

--- a/frontend/src/components/common/Header.tsx
+++ b/frontend/src/components/common/Header.tsx
@@ -51,7 +51,7 @@ const Header = () => {
           );
           const userTeamRole = response.data.teamRole;
 
-          if (userTeamRole === "READER") {
+          if (userTeamRole === "LEADER") {
             navigate(`/team/${teamId}/teamLeader`);
           } else if (userTeamRole === "MATE") {
             navigate(`/team/${teamId}/teamMembers`);

--- a/frontend/src/interface/interface.ts
+++ b/frontend/src/interface/interface.ts
@@ -18,6 +18,9 @@ export interface Team {
   code: string;
   memberLimit: number;
   inviteLink: string;
+  teamName:string;
+  restorationDt:null;
+  teamRole: string;
 }
 
 // 사용자 정보 인터페이스

--- a/frontend/src/state/authState.tsx
+++ b/frontend/src/state/authState.tsx
@@ -102,10 +102,6 @@ export const logout = () => {
 // 홈 화면 검색 상태
 export const searchState = atom({
   key: "searchState",
-  // default: (() => {
-  //   const storedSearch = window.sessionStorage.getItem("search");
-  //   return storedSearch || "";
-  // })() as string,
   default: window.sessionStorage.getItem("search") || "",
 });
 

--- a/frontend/src/views/HomeView.tsx
+++ b/frontend/src/views/HomeView.tsx
@@ -1,9 +1,14 @@
-import { useEffect } from "react";
+import { useEffect, useState } from "react";
 import HomeContent from "../components/Home/HomeContent";
 import HomeCreateTeamBtn from "../components/Home/HomeCreateTeamBtn";
 import HomeSearchBar from "../components/Home/HomeSearchBar";
 
 const homeView = () => {
+  const [search, setSearch] = useState("");
+  const handleSearch = (value: any) => {
+    setSearch(value);
+  };
+
   useEffect(() => {
     const preventGoBack = () => {
       history.go(1);
@@ -18,7 +23,7 @@ const homeView = () => {
 
   return (
     <div>
-      <HomeSearchBar />
+      <HomeSearchBar onSearch={handleSearch} />
       <HomeCreateTeamBtn />
       <HomeContent />
     </div>

--- a/frontend/src/views/SignInView.tsx
+++ b/frontend/src/views/SignInView.tsx
@@ -1,7 +1,5 @@
 import SignIn from "../components/Login/SignIn";
-import Kakao from "../components/Login/Kakao";
 import Naver from "../components/Login/Naver";
-import Google from "../components/Login/Google";
 import styled from "styled-components";
 
 const SignInView = () => {
@@ -9,9 +7,9 @@ const SignInView = () => {
     <>
       <StyledSignInView>
         <SignIn />
-        <Kakao />
+        {/* <Kakao /> */}
         <Naver />
-        <Google />
+        {/* <Google /> */}
       </StyledSignInView>
     </>
   );
@@ -20,8 +18,8 @@ const SignInView = () => {
 export default SignInView;
 
 const StyledSignInView = styled.section`
-display: flex;
-flex-direction: column;
-align-items: center;
-justify-content: center;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
 `;


### PR DESCRIPTION
### 변경 내용

AS-IS
- 해체중인 팀 리스트업
- 페이지 단위로 불러와 검색
- url을 통해 팀 참가
- 카카오, 네이버, 구글 로그인 버튼 생성
- 팀장 READER로 선언

TO-BE
- 해체중인 팀 복구
- 전체 팀 리스트로 불러와 검색
- 참가 버튼을 통해 팀 참가
- 카카오, 구글 버튼 삭제
- 팀장 LEADER로 변경

### 테스트
* [ ] 테스트 코드
* [ ] API 테스트

### 관련 이슈

### 변경 사항 검토
* [ ] api 문서 업데이트

### 특이 사항
아직 마이페이지와 소셜 로그인은 업로드를 하지 않았습니다! 오늘 중으로 다시 pr 올리겠습니다!

### 스크린샷 (선택 사항)
