### PR TITLE
Feat/front calendar connect

### DIFF
--- a/frontend/src/components/Calendar/AddEvent.tsx
+++ b/frontend/src/components/Calendar/AddEvent.tsx
@@ -187,9 +187,9 @@ const AddEvent = ({ originEvent, setEventList, myTeamMemberId }: AddEventProps) 
       <div className='col-span-2'>
         <label htmlFor="color" className='block mt-2 mb-2 text-sm font-medium text-gray-900'>색상</label>
         <select id="color" name="color" value={eventChange.color} onChange={handleEventChange} className='bg-gray-50 border border-gray-300 text-gray-900 text-sm rounded-lg focus:ring-primary-500 focus:border-primary-500 block w-full p-2.5'>
+          <option value="#7aac7a">초록</option>
           <option value="#E21D29">빨강</option>
           <option value="#336699">파랑</option>
-          <option value="#7aac7a">초록</option>
         </select>
       </div>
       <div className='col-span-2'>

--- a/frontend/src/components/Calendar/AddEvent.tsx
+++ b/frontend/src/components/Calendar/AddEvent.tsx
@@ -16,7 +16,7 @@ const AddEvent = ({ originEvent, setEventList, myTeamMemberId }: AddEventProps) 
   const { teamId } = useParams();
 
   // 팀원 목록 값
-  const  [teamParticipants, setTeamParticipants] = useState<any[]>([]);
+  const [teamParticipants, setTeamParticipants] = useState<any[]>([]);
 
   interface ITeamMemberList {
     value: number;
@@ -36,16 +36,16 @@ const AddEvent = ({ originEvent, setEventList, myTeamMemberId }: AddEventProps) 
     try {
       const response = await axiosInstance.get(`/team/${teamId}/participant/list`, {});
       console.log("임포트 셀렉트 컴포넌트 -> ", response);
-      
+
       const memberList = teamMemberList(response.data);
       setTeamParticipants(memberList);
       console.log("임포트 셀렉트 컴포넌트 스테이트 -> ", teamParticipants);
-      
+
     } catch (error) {
       console.error("Error fetching participants:", error);
     }
   };
-  
+
   useEffect(() => {
     fetchParticipants();
   }, [teamId]);
@@ -62,8 +62,10 @@ const AddEvent = ({ originEvent, setEventList, myTeamMemberId }: AddEventProps) 
     repeatCycle: null,
     color: "#ff0000",
     createParticipantId: myTeamMemberId,
-    teamParticipantsIds: [],
+    teamParticipantsIds: [] as any,
   })
+
+  const [participantsIds, setParticipantsIds] = useState<number[]>([]);
 
   // 참여자 외의 정보 입력값 핸들링
   const handleEventChange = (e: React.ChangeEvent<HTMLInputElement | HTMLSelectElement>) => {
@@ -72,15 +74,15 @@ const AddEvent = ({ originEvent, setEventList, myTeamMemberId }: AddEventProps) 
 
   // 참여자 정보 입력값 핸들링
   const handleEventMemberChange = (newValue: MultiValue<any>) => {
-    setEventChange((prev) => ({ ...prev, teamParticipantsIds: newValue as any }));
-  };
+    let result: any = [];
+    newValue.forEach(item => {
+      const member = teamParticipants.find(f => f.value == item.value);
+      result.push(member);
+    });
+    const valuesArray: number[] = result.map((option: any) => option.value);
 
-  // 작성버튼 눌렀을때 참여자 아이디만 저장
-  const handleMemberIds = () => {
-    // teamParticipantsIds 배열에서 value 값만 추출하여 새로운 배열 생성
-    const valuesArray: number[] = teamParticipants.map((option) => option.value);
-    console.log('Values Array:', valuesArray);
-    handleEventMemberChange(valuesArray);
+    setEventChange((prev) => ({ ...prev, teamParticipantsIds: result as any }));
+    setParticipantsIds(valuesArray);
   };
 
   // 새 일정 등록 요청
@@ -89,6 +91,13 @@ const AddEvent = ({ originEvent, setEventList, myTeamMemberId }: AddEventProps) 
     // console.log("입력제목값000000000000 => "+eventChange.title);
     // console.log("0000000000000000"+JSON.stringify(newEvent));
     // console.log("111111111111111111111111111"+JSON.stringify(newEvent));
+
+    console.log(eventChange);
+    console.log(participantsIds);
+
+    let result = eventChange;
+    result.teamParticipantsIds = participantsIds;
+
     try {
       const res = await axiosInstance.post(`/team/${teamId}/schedules`, eventChange, {
         headers: {
@@ -105,7 +114,6 @@ const AddEvent = ({ originEvent, setEventList, myTeamMemberId }: AddEventProps) 
   };
 
   return (
-    // <EventForm>
     <form className="p-4 md:p-5">
       <h2 className="text-lg font-semibold text-gray-900">새 일정 등록</h2>
       <div>
@@ -163,9 +171,9 @@ const AddEvent = ({ originEvent, setEventList, myTeamMemberId }: AddEventProps) 
       <div className='col-span-2'>
         <label htmlFor="repetition" className='block mt-2 mb-2 text-sm font-medium text-gray-900'>반복</label>
         <select id="repetition" className='bg-gray-50 border border-gray-300 text-gray-900 text-sm rounded-lg focus:ring-primary-500 focus:border-primary-500 block w-full p-2.5'>
-          <option value="Does not repeat">반복 안함</option>
-          <option value="Daily">매일</option>
-          <option value="Weekly">매주</option>
+          <option value="NULL">반복 안함</option>
+          <option value="WEEKLY">매주</option>
+          <option value="MONTHLY">매달</option>
         </select>
       </div>
       <div className='col-span-2'>
@@ -191,27 +199,26 @@ const AddEvent = ({ originEvent, setEventList, myTeamMemberId }: AddEventProps) 
           isMulti
           name="teamParticipantsIds"
           classNamePrefix="select"
-          id="teamParticipantsIds" 
+          id="teamParticipantsIds"
           options={teamParticipants}
           value={eventChange.teamParticipantsIds}
           onChange={(newValue: MultiValue<any>) => {
             handleEventMemberChange(newValue);
-            console.log("뉴 밸류 -> ",newValue);
-            console.log("뉴 밸류 에서 접근 -> ",newValue[0]);
-            console.log("뉴 밸류 에서 접근접근 -> ",newValue[0]['value']);
-            console.log("이벤트체인지 -> ",eventChange);
+            // console.log("뉴 밸류 -> ",newValue);
+            // console.log("뉴 밸류 에서 접근 -> ",newValue[0]);
+            // console.log("뉴 밸류 에서 접근접근 -> ",newValue[0]['value']);
+            // console.log("이벤트체인지 -> ",eventChange);
           }}
-          className='basic-multi-select bg-gray-50 border border-gray-300 text-gray-900 text-sm rounded-lg focus:ring-primary-500 focus:border-primary-500 block w-full p-2.5 mb-4' 
+          className='basic-multi-select bg-gray-50 border border-gray-300 text-gray-900 text-sm rounded-lg focus:ring-primary-500 focus:border-primary-500 block w-full p-2.5 mb-4'
         />
-       {/* <input id="teamParticipantsIds" value={eventChange.teamParticipantsIds} onChange={handleEventChange} className='bg-gray-50 border border-gray-300 text-gray-900 text-sm rounded-lg focus:ring-primary-500 focus:border-primary-500 block w-full p-2.5 mb-4'></input> */}
       </div>
-        <CommonSubmitBtn
-          onClick={(e: any) => {
-            handleMemberIds();
-            handleScheduleSubmit(e);
-          }}
-          className='mt-2'
-        >등록</CommonSubmitBtn>
+      <CommonSubmitBtn
+        onClick={(e: any) => {
+          //handleMemberIds();
+          handleScheduleSubmit(e);
+        }}
+        className='mt-2'
+      >등록</CommonSubmitBtn>
     </form>
   );
 };

--- a/frontend/src/components/Calendar/CalendarCategory.tsx
+++ b/frontend/src/components/Calendar/CalendarCategory.tsx
@@ -1,7 +1,12 @@
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
+import { useParams } from 'react-router-dom';
 import styled from "styled-components";
+import axiosInstance from "../../axios";
 
 const CalendarCategory = () => {
+  // 팀 ID
+  const { teamId } = useParams();
+
   // 모달팝업 유무
   const [schdlCtgryModal, setSchdlCtgryModal] = useState(false);
 
@@ -27,6 +32,27 @@ const CalendarCategory = () => {
       color: "yellow",
     },
   ]);
+  
+  // /category/{categoryType}?teamId=1
+  // 카테고리 목록 불러오기
+  const getCategoryList = async () => {
+    try {
+      const res = await axiosInstance({
+        method: "get",
+        url: `/category/schedule?teamId=${teamId}`,
+      });
+      if (res.status === 200) {
+        console.log("카테고리 목록 -> ", res.data);
+        return;
+      }
+    } catch (error) {
+      console.log(error);
+    }
+  };
+
+  useEffect(() => {
+    getCategoryList();
+  }, [teamId]);
 
   // 카테고리 입력 값
   const [catOption, setCatOption] = useState({
@@ -54,6 +80,7 @@ const CalendarCategory = () => {
     setDummyCatList([...dummyCatList, newCatOpt]);
     window.localStorage.setItem("dummyList", JSON.stringify(dummyCatList));
   }
+
 
   return (
     <>

--- a/frontend/src/components/Calendar/CalendarCategory.tsx
+++ b/frontend/src/components/Calendar/CalendarCategory.tsx
@@ -61,11 +61,11 @@ const CalendarCategory = () => {
 
   const AddOption = () => {
     let optId = 4;
-    const newCatOpt = {
-      id: optId,
-      category: catOption.category,
-      color: catOption.color,
-    }
+    // const newCatOpt = {
+    //   id: optId,
+    //   category: catOption.category,
+    //   color: catOption.color,
+    // }
     optId += 1;
     // setDummyCatList([...dummyCatList, newCatOpt]);
     window.localStorage.setItem("dummyList", JSON.stringify(dummyCatList));

--- a/frontend/src/components/Calendar/CalendarCategory.tsx
+++ b/frontend/src/components/Calendar/CalendarCategory.tsx
@@ -17,19 +17,8 @@ const CalendarCategory = () => {
   // 더미 카테고리
   const [dummyCatList, setDummyCatList] = useState([
     {
-      id: 1,
-      category: "카테고리1",
-      color: "yellow",
-    },
-    {
-      id: 2,
-      category: "카테고리2",
-      color: "yellow",
-    },
-    {
-      id: 3,
-      category: "카테고리3",
-      color: "yellow",
+      categoryId: 1,
+      categoryName: "카테고리1",
     },
   ]);
   
@@ -42,7 +31,8 @@ const CalendarCategory = () => {
         url: `/category/schedule?teamId=${teamId}`,
       });
       if (res.status === 200) {
-        console.log("카테고리 목록 -> ", res.data);
+        console.log("카테고리 목록 -> ", res.data.content);
+        setDummyCatList(res.data.content);
         return;
       }
     } catch (error) {
@@ -77,7 +67,7 @@ const CalendarCategory = () => {
       color: catOption.color,
     }
     optId += 1;
-    setDummyCatList([...dummyCatList, newCatOpt]);
+    // setDummyCatList([...dummyCatList, newCatOpt]);
     window.localStorage.setItem("dummyList", JSON.stringify(dummyCatList));
   }
 
@@ -93,9 +83,9 @@ const CalendarCategory = () => {
         </div>
         <ul className="h-48 px-3 pb-3  text-sm text-gray-700" aria-labelledby="dropdownSearchButton">
           {dummyCatList.map((opt) => (
-            <li key={opt.id} className="flex items-center p-2 rounded hover:bg-gray-100">
+            <li key={opt.categoryId} className="flex items-center p-2 rounded hover:bg-gray-100">
               <input type="checkbox" value="" className="w-4 h-4 text-blue-600 bg-gray-100 border-gray-300 rounded focus:ring-blue-50" />
-              <label className="w-full ms-2 text-sm font-medium text-gray-900 rounded">{opt.category}</label>
+              <label className="w-full ms-2 text-sm font-medium text-gray-900 rounded">{opt.categoryName}</label>
             </li>
           ))}
         </ul>

--- a/frontend/src/components/Calendar/TeamCalender.tsx
+++ b/frontend/src/components/Calendar/TeamCalender.tsx
@@ -142,15 +142,18 @@ const TeamCalender = () => {
   // 일정 삭제
   const handleEventDelete = async (e: any) => {
     e.preventDefault();
-    if (!window.confirm(`번째 일정을 삭제하시겠습니까?`)) return;
+    if (!window.confirm(`일정을 삭제하시겠습니까?`)) return;
     const eventId = event.id;
     try {
-      const res = await axiosInstance.delete(`/schedules`, {
+      // team/{teamId}/schedules/simple/{schedule_id}
+      const res = await axiosInstance.delete(`/team/${teamId}/schedules/simple/${eventId}`, {
         headers: {
           "Content-Type": "application/json"
         },
         data: {
-          eventId
+          scheduleId: eventId,
+          teamId: teamId,
+          teamParticipantId: myTeamMemberId,
         }
       });
       if (res.status === 201) {
@@ -216,7 +219,7 @@ const TeamCalender = () => {
               <div className="p-4 md:p-5">
                 <h2 className="text-xl mt-4 mb-4 font-semibold text-gray-900">{event.title}</h2>
                 <p>
-                  {/* 일정 번호: {event.id} */}
+                  일정 번호: {event.id}
                   {/* 이름: {event.title}<br /> */}
                   <div className="mb-3">
                     <span className="mr-10 text-gray-500">일시</span><span className="">{event.start.toJSON()}</span>
@@ -227,9 +230,13 @@ const TeamCalender = () => {
                   <div className="mb-3">
                     <span className="mr-10 text-gray-500">장소</span>{event.place}
                   </div>
-                  <div className="mb-5">
+                  <div className="mb-3">
                     <span className="text-gray-500 mr-3">카테고리</span>{event.groupId}
                   </div>
+                  {/* <div className="mb-5">
+                    <span className="text-gray-500 mr-3">참가자</span>
+                    {event.groupId}
+                  </div> */}
                 </p>
                 <button onClick={toggleIsEdit} className="bg-white border-1 border-gray-300 mr-2">수정</button>
                 <button onClick={handleEventDelete} className="bg-white border-1 border-gray-300">삭제</button>


### PR DESCRIPTION
### 변경 내용
AS-IS
새 일정 등록시 참여자 선택에서 선택한 팀원의 ID만 보내져야 하는데 ID와 닉네임이 함께 보내지는 이슈 존재
참여자 정보 값이 제대로 넘어가지 않아서 등록버튼을 두번 클릭해야 등록되는 이슈 존재
달력 옆에 있는 카테고리 목록에 가짜 카테고리 목록 렌더링

TO-BE
DB와 연결된 일정삭제 기능 구현
새 일정 등록시 참여자 선택에서 선택한 팀원의 ID만 보내져야 하는데 ID와 닉네임이 함께 보내지는 이슈 해결
참여자 정보 값이 제대로 넘어가지 않아서 등록버튼을 두번 클릭해야 등록되는 이슈 해결
달력 옆에 있는 카테고리 목록에 DB에 있는 카테고리 목록 렌더링 되도록 구현

### 테스트
* [ ] 테스트 코드
* [ ] API 테스트

### 관련 이슈
없음

### 변경 사항 검토
* [ ] api 문서 업데이트

### 특이 사항
라이브러리 새로 설치한것 때문에 실행 안되시면 npm istall 명령어 한번 쳐주세요!