### PR TITLE
Feat/front calendar connect

### DIFF
--- a/frontend/src/components/Calendar/AddEvent.tsx
+++ b/frontend/src/components/Calendar/AddEvent.tsx
@@ -3,15 +3,16 @@ import { useParams } from "react-router-dom";
 import axiosInstance from "../../axios";
 import styled from "styled-components";
 import Select, { MultiValue } from 'react-select';
-// import SelectTeamMember from "./SelectTeamMember.tsx";
+import { ICategoryList } from "../../interface/interface.ts"
 
 type AddEventProps = {
   originEvent: any,
   setEventList: React.Dispatch<React.SetStateAction<any>>,
+  categoryList: ICategoryList[],
   myTeamMemberId: number,
 }
 
-const AddEvent = ({ originEvent, setEventList, myTeamMemberId }: AddEventProps) => {
+const AddEvent = ({ originEvent, setEventList, categoryList, myTeamMemberId }: AddEventProps) => {
   // 현재 페이지의 팀 아이디
   const { teamId } = useParams();
 
@@ -179,9 +180,9 @@ const AddEvent = ({ originEvent, setEventList, myTeamMemberId }: AddEventProps) 
       <div className='col-span-2'>
         <label htmlFor="categoryId" className='block mt-2 mb-2 text-sm font-medium text-gray-900'>카테고리</label>
         <select id="categoryId" name='categoryId' value={eventChange.categoryId} onChange={handleEventChange} className='bg-gray-50 border border-gray-300 text-gray-900 text-sm rounded-lg focus:ring-primary-500 focus:border-primary-500 block w-full p-2.5'>
-          <option value="1">주간회의</option>
-          <option value="2">회의</option>
-          <option value="3">미팅</option>
+          {categoryList.map((item)=>(
+            <option key={item.categoryId} value={item.categoryId}>{item.categoryName}</option>
+          ))}
         </select>
       </div>
       <div className='col-span-2'>
@@ -214,7 +215,6 @@ const AddEvent = ({ originEvent, setEventList, myTeamMemberId }: AddEventProps) 
       </div>
       <CommonSubmitBtn
         onClick={(e: any) => {
-          //handleMemberIds();
           handleScheduleSubmit(e);
         }}
         className='mt-2'

--- a/frontend/src/components/Calendar/CalendarCategory.tsx
+++ b/frontend/src/components/Calendar/CalendarCategory.tsx
@@ -8,10 +8,10 @@ const CalendarCategory = () => {
   const { teamId } = useParams();
 
   // 모달팝업 유무
-  const [schdlCtgryModal, setSchdlCtgryModal] = useState(false);
+  const [categoryModal, setCategoryModal] = useState(false);
 
   const toggleCat = () => {
-    setSchdlCtgryModal(!schdlCtgryModal);
+    setCategoryModal(!categoryModal);
   };
 
   // 카테고리 목록
@@ -91,7 +91,7 @@ const CalendarCategory = () => {
         </ul>
       </div>
       {/* 날짜클릭 모달 */}
-      {schdlCtgryModal && (
+      {categoryModal && (
         <Modal>
           <Overlay
             onClick={toggleCat}

--- a/frontend/src/components/Calendar/CalendarCategory.tsx
+++ b/frontend/src/components/Calendar/CalendarCategory.tsx
@@ -14,8 +14,8 @@ const CalendarCategory = () => {
     setSchdlCtgryModal(!schdlCtgryModal);
   };
 
-  // 더미 카테고리
-  const [dummyCatList, setDummyCatList] = useState([
+  // 카테고리 목록
+  const [categoryList, setCategoryList] = useState([
     {
       categoryId: 1,
       categoryName: "카테고리1",
@@ -32,7 +32,7 @@ const CalendarCategory = () => {
       });
       if (res.status === 200) {
         console.log("카테고리 목록 -> ", res.data.content);
-        setDummyCatList(res.data.content);
+        setCategoryList(res.data.content);
         return;
       }
     } catch (error) {
@@ -68,7 +68,7 @@ const CalendarCategory = () => {
     // }
     optId += 1;
     // setDummyCatList([...dummyCatList, newCatOpt]);
-    window.localStorage.setItem("dummyList", JSON.stringify(dummyCatList));
+    window.localStorage.setItem("dummyList", JSON.stringify(categoryList));
   }
 
 
@@ -82,7 +82,7 @@ const CalendarCategory = () => {
           </button>
         </div>
         <ul className="h-48 px-3 pb-3  text-sm text-gray-700" aria-labelledby="dropdownSearchButton">
-          {dummyCatList.map((opt) => (
+          {categoryList.map((opt) => (
             <li key={opt.categoryId} className="flex items-center p-2 rounded hover:bg-gray-100">
               <input type="checkbox" value="" className="w-4 h-4 text-blue-600 bg-gray-100 border-gray-300 rounded focus:ring-blue-50" />
               <label className="w-full ms-2 text-sm font-medium text-gray-900 rounded">{opt.categoryName}</label>

--- a/frontend/src/components/Calendar/CalendarCategory.tsx
+++ b/frontend/src/components/Calendar/CalendarCategory.tsx
@@ -7,6 +7,9 @@ const CalendarCategory = () => {
   // 팀 ID
   const { teamId } = useParams();
 
+  // 현재 페이지의 사용자 팀 멤버 Id(participant)
+  const [myTeamMemberId, setMyTeamMemberId] = useState<number | undefined>(undefined);
+
   // 모달팝업 유무
   const [categoryModal, setCategoryModal] = useState(false);
 
@@ -39,38 +42,66 @@ const CalendarCategory = () => {
       console.log(error);
     }
   };
+  
+  // 작성자 정보를 위한 현재 팀의 사용자 팀 멤버 id(participant) 가져오기
+  const fetchMyTeamMemberId = async () => {
+    try {
+      // 사용자가 속해있는 팀 목록과 닉네임등의 정보를 불러옴
+      const response = await axiosInstance.get("/member/participants", {});
+      // 사용자가 가입한 팀 목록중에 현재 팀id의 정보와 맞는 팀 내 내정보 값만 가져옴
+      const myTeamMemberInfo = response.data.find(
+        (item: { teamId: number }) => item.teamId === Number(teamId),
+      );
+      const authorTeamMemberId = myTeamMemberInfo.teamParticipantsId;      
+      setMyTeamMemberId(authorTeamMemberId);
+      console.log("작성자 팀멤버 아이디 카테고리-> ",myTeamMemberId);
+    } catch (error) {
+      console.error("Error fetching participants:", error);
+    }
+  };
 
   useEffect(() => {
     getCategoryList();
+    fetchMyTeamMemberId();
   }, [teamId]);
 
   // 카테고리 입력 값
-  const [catOption, setCatOption] = useState({
-    category: "",
+  const [categoryInput, setCategoryInput] = useState({
+    teamId: teamId,
+    createTeamParticipantId: myTeamMemberId,
+    categoryName: "",
+    categoryType: "schedule",
     color: "",
   });
 
-  // 바뀌는값
+  // 카테고리 입력값 핸들링
   const handleChangeOption = (e: any) => {
     console.log(e.target.value);
-    setCatOption({
-      ...catOption,
+    setCategoryInput({
+      ...categoryInput,
       [e.target.name]: e.target.value,
     })
+    console.log(categoryInput);
   };
 
-  const AddOption = () => {
-    let optId = 4;
-    // const newCatOpt = {
-    //   id: optId,
-    //   category: catOption.category,
-    //   color: catOption.color,
-    // }
-    optId += 1;
-    // setDummyCatList([...dummyCatList, newCatOpt]);
-    window.localStorage.setItem("dummyList", JSON.stringify(categoryList));
-  }
-
+  const AddCategory = async (e: any) => {
+    // /category
+    e.preventDefault();
+    try {
+      const res = await axiosInstance.post(`/category`, categoryInput, {
+        headers: {
+          "Content-Type": "application/json"
+        },
+      });
+      if (res.status === 200) {
+        console.log("카테고리 옵션이 추가되었습니다 -> ", res);
+        // setCategoryList(res.data.content);
+        return;
+      }
+    } catch (error) {
+      console.log(error);
+    }
+  };
 
   return (
     <>
@@ -90,7 +121,7 @@ const CalendarCategory = () => {
           ))}
         </ul>
       </div>
-      {/* 날짜클릭 모달 */}
+      {/* 카테고리 추가 버튼 클릭시 모달 */}
       {categoryModal && (
         <Modal>
           <Overlay
@@ -101,29 +132,28 @@ const CalendarCategory = () => {
               <h2 className="text-lg font-semibold text-gray-900">카테고리 추가</h2>
               <CategoryForm>
                 <div className="col-span-2">
-
                 </div>
                 <label className='block mt-2 mb-2 text-sm font-medium text-gray-900'>카테고리 이름</label>
                 <input
                   placeholder='카테고리명'
-                  name="category"
-                  value={catOption.category}
+                  name="categoryName"
+                  value={categoryInput.categoryName}
                   onChange={handleChangeOption}
                   className='block p-2.5 w-full text-sm text-gray-900 bg-gray-50 rounded-lg border border-gray-300 focus:ring-blue-500 focus:border-blue-500'
                 ></input>
                 <label className='block mt-2 mb-2 text-sm font-medium text-gray-900'>색상</label>
                 <select
                   name="color"
-                  value={catOption.color}
+                  value={categoryInput.color}
                   onChange={handleChangeOption}
                   className='block p-2.5 mb-4 w-full text-sm text-gray-900 bg-gray-50 rounded-lg border border-gray-300 focus:ring-blue-500 focus:border-blue-500'
                 >
-                  <option value="red">red</option>
-                  <option value="yellow">yellow</option>
-                  <option value="blue">blue</option>
+                  <option value="#7aac7a">초록</option>
+                  <option value="#E21D29">빨강</option>
+                  <option value="#336699">파랑</option>
                 </select>
                 <CommonSubmitBtn
-                  onClick={AddOption}
+                  onClick={AddCategory}
                 >등록</CommonSubmitBtn>
               </CategoryForm>
               <CloseModal
@@ -135,7 +165,6 @@ const CalendarCategory = () => {
           </ModalContent>
         </Modal>
       )}
-      {/* </div> */}
     </>
   );
 };

--- a/frontend/src/components/Calendar/TeamCalender.tsx
+++ b/frontend/src/components/Calendar/TeamCalender.tsx
@@ -9,6 +9,7 @@ import styled from "styled-components";
 import AddEvent from "./AddEvent.tsx";
 import EditEvent from "./EditEvent.tsx";
 import axiosInstance from "../../axios";
+import { ConvertedEvent, ICategoryList } from "../../interface/interface.ts"
 
 const TeamCalender = () => {
   const navigate = useNavigate();
@@ -25,6 +26,14 @@ const TeamCalender = () => {
 
   // 일정 전체 목록
   const [eventList, setEventList] = useState<any>([]);
+
+  // 카테고리 목록
+  const [categoryList, setCategoryList] = useState<ICategoryList[]>([
+    {
+      categoryId: 1,
+      categoryName: "카테고리1",
+    },
+  ]);
 
   // 달력 일정 각각 state 핸들링용
   const [event, setEvent] = useState<any>([]);
@@ -80,22 +89,6 @@ const TeamCalender = () => {
   const toggleIsEdit = () => setIsEdit(!isEdit);
 
   // 일정목록 렌더링을 위한 변환
-  interface ConvertedEvent {
-    id: number;
-    start: string;
-    end: string;
-    title: string;
-    borderColor: string;
-    backgroundColor: string;
-    extendedProps: {
-      content: string;
-      place: string;
-      scheduleType: string;
-      category: string;
-      categoryName: string;
-    };
-  }
-  
   const convertEvents = (events: any[]): ConvertedEvent[] => {
     return events.map(event => ({
       id: event.scheduleId,
@@ -134,9 +127,27 @@ const TeamCalender = () => {
     }
   };
 
+  // 카테고리 목록 불러오기
+  const getCategoryList = async () => {
+    try {
+      const res = await axiosInstance({
+        method: "get",
+        url: `/category/schedule?teamId=${teamId}`,
+      });
+      if (res.status === 200) {
+        console.log("카테고리 목록 -> ", res.data.content);
+        setCategoryList(res.data.content);
+        return;
+      }
+    } catch (error) {
+      console.log(error);
+    }
+  };
+
   useEffect(() => {
     getAllEvents();
     fetchMyTeamMemberId();
+    getCategoryList();
   }, [teamId]);
 
   // 일정 삭제
@@ -260,7 +271,7 @@ const TeamCalender = () => {
             onClick={toggleFormModal}
           ></Overlay>
           <ModalContent>
-            <AddEvent originEvent={event} setEventList={setEventList} myTeamMemberId={myTeamMemberId || 0} />
+            <AddEvent originEvent={event} setEventList={setEventList} categoryList={categoryList} myTeamMemberId={myTeamMemberId || 0} />
             <CloseModal
               onClick={toggleFormModal}
             >

--- a/frontend/src/interface/interface.ts
+++ b/frontend/src/interface/interface.ts
@@ -55,3 +55,26 @@ export interface TeamParticipant {
   participantsProfileUrl: string;
   teamNickName: string;
 }
+
+// 카테고리 목록
+export interface ICategoryList {
+  categoryId: number;
+  categoryName: string;
+}
+
+// 일정목록 렌더링을 위한 타입
+export interface ConvertedEvent {
+  id: number;
+  start: string;
+  end: string;
+  title: string;
+  borderColor: string;
+  backgroundColor: string;
+  extendedProps: {
+    content: string;
+    place: string;
+    scheduleType: string;
+    category: string;
+    categoryName: string;
+  };
+}


### PR DESCRIPTION
### 변경 내용
AS-IS
캘린더 새 일정 추가시 임의의 카테고리 명으로 일정 작성

TO-BE
캘린더 새 일정 추가시 실제 있는 카테고리 목록중에서 선택하여 일정 작성되도록 구현
가짜 카테고리 목록 쓸때의 변수명 dummyCatList -> categoryList 변경
카테고리 추가하는 폼 모달창의 변수명이 모호하여 변수명 변경

### 테스트
* [ ] 테스트 코드
* [ ] API 테스트

### 관련 이슈
없음
### 변경 사항 검토
* [ ] api 문서 업데이트

### 특이 사항
없음