### PR TITLE
Add: 로그인 전 메인화면 폰트, 버튼 색 메인색으로 변경

### DIFF
--- a/frontend/src/components/MainContents.tsx
+++ b/frontend/src/components/MainContents.tsx
@@ -7,12 +7,12 @@ const MainContents = () => {
     <MainContentsSpan>
       <div>
         <h2 className="mb-4 text-4xl font-extrabold leading-none tracking-tight text-gray-900 md:text-5xl lg:text-6xl">
-          팀원들과의 원활한 협업을 위한 <span className="text-green-600 dark:text-green-500">TeamMate,</span> 지금 시작해보세요.
+          팀원들과의 원활한 협업을 위한 <span className="text-mainGreen">TeamMate,</span> 지금 시작해보세요.
         </h2>
         <p className="mb-4 text-lg font-normal text-gray-500 lg:text-xl">
           글을 작성하고 계획을 세우며, 다른 이들과 협업해보세요.
         </p>
-        <Link to="/signUp" className="inline-flex items-center justify-center px-5 py-3 text-base font-medium text-center text-white bg-green-700 rounded-lg hover:bg-green-800 focus:ring-4 focus:ring-blue-300">
+        <Link to="/signUp" className="inline-flex items-center justify-center px-5 py-3 text-base font-medium text-center text-white bg-mainGreen rounded-lg hover:bg-green-800 focus:ring-4 focus:ring-green-300">
           시작하기
         </Link>
       </div>

--- a/frontend/tailwind.config.js
+++ b/frontend/tailwind.config.js
@@ -8,7 +8,11 @@ export default {
     './src/components/**/*.{tsx,js,ts}',
   ],
   theme: {
-    extend: {},
+    extend: {
+      colors: {
+        mainGreen: '#A3CCA3'
+      }
+    },
   },
   plugins: [require("daisyui")],
 }


### PR DESCRIPTION
### 변경 내용
AS-IS
로그인 전 메인화면 폰트색과 버튼색이 진한 초록색 이였음

TO-BE
로그인 전 메인화면 폰트색과 버튼색을 메인색(#A3CCA3)으로 수정

### 테스트
* [ ] 테스트 코드
* [ ] API 테스트

### 관련 이슈
없음

### 변경 사항 검토
* [ ] api 문서 업데이트

### 특이 사항
없음

### 스크린샷 (선택 사항)
![image](https://github.com/100backfro/teammate/assets/110381560/e075edaa-c6bc-4062-a561-3c31c8b4405b)