### PR TITLE
Feat/front calendar connect

### DIFF
--- a/frontend/src/components/Calendar/Calendar.tsx
+++ b/frontend/src/components/Calendar/Calendar.tsx
@@ -1,0 +1,64 @@
+import { useState, useEffect } from "react";
+import { useParams } from "react-router-dom";
+import { ICategoryList } from "../../interface/interface.ts"
+import axiosInstance from "../../axios";
+import getCategoryList from "./GetCategoryList.tsx";
+import TeamCalender from "./TeamCalender"
+import CalendarCategory from "./CalendarCategory"
+
+const Calendar = () => {
+  // 팀 아이디
+  const { teamId } = useParams();
+
+  // 카테고리 목록
+  const [categoryList, setCategoryList] = useState<ICategoryList[]>([
+    {
+      categoryId: 1,
+      categoryName: "카테고리1",
+    },
+  ]);
+
+  // 현재 페이지의 사용자 팀 멤버 Id(participant)
+  const [myTeamMemberId, setMyTeamMemberId] = useState<number | undefined>(undefined);
+
+  const fetchMyTeamMemberId = async () => {
+    try {
+      // 사용자가 속해있는 팀 목록과 닉네임등의 정보를 불러옴
+      const response = await axiosInstance.get("/member/participants", {});
+      // 사용자가 가입한 팀 목록중에 현재 팀id의 정보와 맞는 팀 내 내정보 값만 가져옴
+      const myTeamMemberInfo = response.data.find(
+        (item: { teamId: number }) => item.teamId === Number(teamId),
+      );
+      const authorTeamMemberId = myTeamMemberInfo.teamParticipantsId;      
+      setMyTeamMemberId(authorTeamMemberId);
+      // console.log("작성자 팀멤버 아이디 -> ",myTeamMemberId);
+    } catch (error) {
+      console.error("Error fetching participants:", error);
+    }
+  };
+
+  useEffect(() => {
+    const getCategoryItems = async() => {
+      const response = await getCategoryList(teamId);
+      setCategoryList(response);
+    }
+
+    fetchMyTeamMemberId();
+    getCategoryItems();
+  }, [teamId]);
+
+  return (
+    <div className="flex min-h-screen flex-col items-center justify-between">
+      <div className="grid grid-cols-10">
+        <div className="col-span-8">
+          <TeamCalender categoryList={categoryList} myTeamMemberId={myTeamMemberId} />
+        </div>
+        <div className="ml-8 w-full mt-16 lg:h-1/2">
+          <CalendarCategory categoryList={categoryList} myTeamMemberId={myTeamMemberId} setCategoryList={setCategoryList} />
+        </div>
+      </div>
+    </div>
+  )
+}
+
+export default Calendar;

--- a/frontend/src/components/Calendar/CalendarCategory.tsx
+++ b/frontend/src/components/Calendar/CalendarCategory.tsx
@@ -1,14 +1,12 @@
-import { useState, useEffect, useRef } from 'react';
+import { useState, useRef } from 'react';
 import { useParams } from 'react-router-dom';
 import styled from "styled-components";
 import axiosInstance from "../../axios";
+import getCategoryList from "./GetCategoryList.tsx";
 
-const CalendarCategory = () => {
+const CalendarCategory = ({ categoryList, myTeamMemberId, setCategoryList }: any) => {
   // 팀 ID
   const { teamId } = useParams();
-
-  // 현재 페이지의 사용자 팀 멤버 Id(participant)
-  const [myTeamMemberId, setMyTeamMemberId] = useState<number>();
 
   // 모달팝업 유무
   const [categoryModal, setCategoryModal] = useState(false);
@@ -19,54 +17,6 @@ const CalendarCategory = () => {
 
   // input 요소
   const categoryNameInput = useRef<HTMLInputElement | null>(null);
-
-  // 카테고리 목록
-  const [categoryList, setCategoryList] = useState([
-    {
-      categoryId: 1,
-      categoryName: "카테고리1",
-    },
-  ]);
-  
-  // 카테고리 목록 불러오기
-  const getCategoryList = async () => {
-    try {
-      const res = await axiosInstance({
-        method: "get",
-        url: `/category/schedule?teamId=${teamId}`,
-      });
-      if (res.status === 200) {
-        console.log("카테고리 목록 -> ", res.data.content);
-        setCategoryList(res.data.content);
-        return;
-      }
-    } catch (error) {
-      console.log(error);
-    }
-  };
-  
-  // 작성자 정보를 위한 현재 팀의 사용자 팀 멤버 id(participant) 가져오기
-  useEffect(() => {
-    const fetchMyTeamMemberId = async () => {
-      try {
-        const response = await axiosInstance.get("/member/participants", {});
-        const myTeamMemberInfo = response.data.find(
-          (item: { teamId: number }) => item.teamId === Number(teamId),
-        );
-        const authorTeamMemberId = myTeamMemberInfo.teamParticipantsId;      
-        setMyTeamMemberId(authorTeamMemberId);
-        console.log("작성자 팀멤버 아이디 카테고리-> ",myTeamMemberId);
-      } catch (error) {
-        console.error("Error fetching participants:", error);
-      }
-    };
-    fetchMyTeamMemberId();
-  }, [teamId]);
-
-  useEffect(() => {
-    getCategoryList();
-    // fetchMyTeamMemberId();
-  }, [teamId]);
 
   // 카테고리 입력 값
   const [categoryInput, setCategoryInput] = useState({
@@ -119,6 +69,11 @@ const CalendarCategory = () => {
     }
   }
 
+  const getCategoryItems = async(teamId: any) => {
+    const response = await getCategoryList(teamId);
+    setCategoryList(response);
+  } 
+
   // 카테고리 삭제
   const handleCategoryDelete = async (e: any) => {
     try {
@@ -134,7 +89,7 @@ const CalendarCategory = () => {
       );
       if (res.status === 200) {
         console.log("카테고리 삭제 성공!! -> ", res);
-        getCategoryList();
+        getCategoryItems(teamId);
         return;
       }
     } catch (error) {
@@ -152,7 +107,7 @@ const CalendarCategory = () => {
           </button>
         </div>
         <ul className="h-48 px-3 pb-3  text-sm text-gray-700" aria-labelledby="dropdownSearchButton">
-          {categoryList.map((opt) => (
+          {categoryList.map((opt: any) => (
             <li key={opt.categoryId} className="flex items-center p-2 rounded hover:bg-gray-100">
               <input type="checkbox" value="" className="w-4 h-4 checkbox checkbox-success text-green-600 bg-gray-100 border-gray-300 rounded focus:ring-green-50" />
               <label className="w-full ms-2 text-sm font-medium text-gray-900 rounded">{opt.categoryName}</label>

--- a/frontend/src/components/Calendar/CalendarView.tsx
+++ b/frontend/src/components/Calendar/CalendarView.tsx
@@ -1,12 +1,12 @@
 import { useState, useEffect } from "react";
 import { useParams } from "react-router-dom";
 import { ICategoryList } from "../../interface/interface.ts"
-import axiosInstance from "../../axios";
+import axiosInstance from "../../axios.tsx";
 import getCategoryList from "./GetCategoryList.tsx";
-import TeamCalender from "./TeamCalender"
-import CalendarCategory from "./CalendarCategory"
+import TeamCalender from "./TeamCalender.tsx"
+import CalendarCategory from "./CalendarCategory.tsx"
 
-const Calendar = () => {
+const CalendarView = () => {
   // 팀 아이디
   const { teamId } = useParams();
 
@@ -48,17 +48,15 @@ const Calendar = () => {
   }, [teamId]);
 
   return (
-    <div className="flex min-h-screen flex-col items-center justify-between">
-      <div className="grid grid-cols-10">
-        <div className="col-span-8">
-          <TeamCalender categoryList={categoryList} myTeamMemberId={myTeamMemberId} />
-        </div>
-        <div className="ml-8 w-full mt-16 lg:h-1/2">
-          <CalendarCategory categoryList={categoryList} myTeamMemberId={myTeamMemberId} setCategoryList={setCategoryList} />
-        </div>
+    <>
+      <div className="col-span-8">
+        <TeamCalender categoryList={categoryList} myTeamMemberId={myTeamMemberId} />
       </div>
-    </div>
+      <div className="ml-8 w-full mt-16 lg:h-1/2">
+        <CalendarCategory categoryList={categoryList} myTeamMemberId={myTeamMemberId} setCategoryList={setCategoryList} />
+      </div>
+    </>
   )
 }
 
-export default Calendar;
+export default CalendarView;

--- a/frontend/src/components/Calendar/GetCategoryList.tsx
+++ b/frontend/src/components/Calendar/GetCategoryList.tsx
@@ -1,0 +1,20 @@
+import axiosInstance from "../../axios";
+
+const getCategoryList = async (teamId: any) => {
+  try {
+    const res = await axiosInstance({
+      method: "get",
+      url: `/category/schedule?teamId=${teamId}`,
+    });
+    if (res.status === 200) {
+      const categoryList = res.data.content;
+      console.log("카테고리 목록 -> ", res.data.content);
+      // setCategoryList(res.data.content);
+      return categoryList;
+    }
+  } catch (error) {
+    console.log(error);
+  }
+};
+
+export default getCategoryList;

--- a/frontend/src/components/Calendar/TeamCalender.tsx
+++ b/frontend/src/components/Calendar/TeamCalender.tsx
@@ -9,16 +9,13 @@ import styled from "styled-components";
 import AddEvent from "./AddEvent.tsx";
 import EditEvent from "./EditEvent.tsx";
 import axiosInstance from "../../axios";
-import { ConvertedEvent, ICategoryList } from "../../interface/interface.ts"
+import { ConvertedEvent } from "../../interface/interface.ts"
 
-const TeamCalender = () => {
+const TeamCalender = ({ categoryList, myTeamMemberId }: any) => {
   const navigate = useNavigate();
 
   // 팀 아이디
   const { teamId } = useParams();
-
-  // 현재 페이지의 사용자 팀 멤버 Id(participant)
-  const [myTeamMemberId, setMyTeamMemberId] = useState<number | undefined>(undefined);
 
   // 모달팝업 유무 값
   const [eventDetailModal, setEventDetailModal] = useState<any>(false);
@@ -26,14 +23,6 @@ const TeamCalender = () => {
 
   // 일정 전체 목록
   const [eventList, setEventList] = useState<any>([]);
-
-  // 카테고리 목록
-  const [categoryList, setCategoryList] = useState<ICategoryList[]>([
-    {
-      categoryId: 1,
-      categoryName: "카테고리1",
-    },
-  ]);
 
   // 달력 일정 각각 state 핸들링용
   const [event, setEvent] = useState<any>([]);
@@ -44,23 +33,6 @@ const TeamCalender = () => {
   };
   const toggleFormModal = () => {
     setEventFormModal(!eventFormModal);
-  };
-
-  // 작성자 정보를 위한 현재 팀의 사용자 팀 멤버 id(participant) 가져오기
-  const fetchMyTeamMemberId = async () => {
-    try {
-      // 사용자가 속해있는 팀 목록과 닉네임등의 정보를 불러옴
-      const response = await axiosInstance.get("/member/participants", {});
-      // 사용자가 가입한 팀 목록중에 현재 팀id의 정보와 맞는 팀 내 내정보 값만 가져옴
-      const myTeamMemberInfo = response.data.find(
-        (item: { teamId: number }) => item.teamId === Number(teamId),
-      );
-      const authorTeamMemberId = myTeamMemberInfo.teamParticipantsId;      
-      setMyTeamMemberId(authorTeamMemberId);
-      console.log("작성자 팀멤버 아이디 -> ",myTeamMemberId);
-    } catch (error) {
-      console.error("Error fetching participants:", error);
-    }
   };
 
   // 일정클릭 핸들링
@@ -108,46 +80,27 @@ const TeamCalender = () => {
   };
   
   // 일정목록 불러오기
-  const getAllEvents = async () => {
-    try {
-      const res = await axiosInstance({
-        method: "get",
-        url: `/team/${teamId}/schedules/calendar`,
-      });
-      if (res.status === 200) {
-        console.log(res.data.content);
-        // 데이터 변환
-        const convertedEvents = convertEvents(res.data.content);
-        console.log(convertedEvents);
-        setEventList(convertedEvents);
-        return;
-      }
-    } catch (error) {
-      console.log(error);
-    }
-  };
-
-  // 카테고리 목록 불러오기
-  const getCategoryList = async () => {
-    try {
-      const res = await axiosInstance({
-        method: "get",
-        url: `/category/schedule?teamId=${teamId}`,
-      });
-      if (res.status === 200) {
-        console.log("카테고리 목록 -> ", res.data.content);
-        setCategoryList(res.data.content);
-        return;
-      }
-    } catch (error) {
-      console.log(error);
-    }
-  };
-
   useEffect(() => {
+    const getAllEvents = async () => {
+      try {
+        const res = await axiosInstance({
+          method: "get",
+          url: `/team/${teamId}/schedules/calendar`,
+        });
+        if (res.status === 200) {
+          console.log(res.data.content);
+          // 데이터 변환
+          const convertedEvents = convertEvents(res.data.content);
+          console.log(convertedEvents);
+          setEventList(convertedEvents);
+          return;
+        }
+      } catch (error) {
+        console.log(error);
+      }
+    };
+
     getAllEvents();
-    fetchMyTeamMemberId();
-    getCategoryList();
   }, [teamId]);
 
   // 일정 삭제

--- a/frontend/src/router/router.tsx
+++ b/frontend/src/router/router.tsx
@@ -9,7 +9,8 @@ import SocialServiceCallbackPage from "../components/Login/SocialServiceCallback
 import HomeView from "../views/HomeView";
 import TeamContent from "../components/TeamPage/TeamContent";
 
-import Calender from "../views/Calender";
+// import Calender from "../views/Calender";
+import Calender from "../components/Calendar/Calendar";
 import CreateTextView from "../views/CreateTextView";
 import TextEditorView from "../views/TextEditorView";
 import DocumentListView from "../views/DocumentListView";

--- a/frontend/src/router/router.tsx
+++ b/frontend/src/router/router.tsx
@@ -9,8 +9,8 @@ import SocialServiceCallbackPage from "../components/Login/SocialServiceCallback
 import HomeView from "../views/HomeView";
 import TeamContent from "../components/TeamPage/TeamContent";
 
-// import Calender from "../views/Calender";
-import Calender from "../components/Calendar/Calendar";
+import Calender from "../views/Calender";
+// import Calender from "../components/Calendar/Calendar";
 import CreateTextView from "../views/CreateTextView";
 import TextEditorView from "../views/TextEditorView";
 import DocumentListView from "../views/DocumentListView";

--- a/frontend/src/views/Calender.tsx
+++ b/frontend/src/views/Calender.tsx
@@ -1,19 +1,12 @@
-import TeamCalender from "../components/Calendar/TeamCalender"
-import CalendarCategory from "../components/Calendar/CalendarCategory"
+import CalendarView from "../components/Calendar/CalendarView";
 
 const Calender = () => {
   return (
     <div className="flex min-h-screen flex-col items-center justify-between">
       <div className="grid grid-cols-10">
-        <div className="col-span-8">
-          <TeamCalender />
-        </div>
-        <div className="ml-8 w-full mt-16 lg:h-1/2">
-          <CalendarCategory />
-        </div>
+        <CalendarView />
       </div>
     </div>
-
   )
 }
 


### PR DESCRIPTION
### 변경 내용
AS-IS
카테고리 컴포넌트, 캘린더 컴포넌트 각각에서 카테고리 리스트와 사용자 팀 내에서의 id 값을 따로 불러옴
달력 옆의 카테고리 목록에서는 추가, 삭제가 바로 반영되지만 새 일정 추가 폼에서는 새로고침 이후에 반영됨

TO-BE
카테고리 목록, 사용자의 팀 내에서의 id를 공통으로 한번만 불러와서 다룰 수 있도록 컴포넌트 구조 변경
새 일정 추가 폼에서도 카테고리 변동사항이 바로 적용될 수 있도록 수정
카테고리 리스트 불러오는 역할을 하는 함수 선언은 별도의 컴포넌트로 분리

### 테스트
* [ ] 테스트 코드
* [ ] API 테스트

### 관련 이슈
없음

### 변경 사항 검토
* [ ] api 문서 업데이트

### 특이 사항
컴포넌트명과 구조가 바뀐것들이 있어서 혹시나 경로 문제나는게 있다면 알려주세요! 수정하겠습니다.