### PR TITLE
Fix: 카테고리 추가 폼에서 타입 선택이 안되는 이슈 수정

### DIFF
--- a/frontend/src/components/Calendar/CalendarCategory.tsx
+++ b/frontend/src/components/Calendar/CalendarCategory.tsx
@@ -162,8 +162,7 @@ const CalendarCategory = ({ categoryList, myTeamMemberId, setCategoryList }: any
                 <label className='block mt-2 mb-2 text-sm font-medium text-gray-900'>타입</label>
                 <select
                   name="categoryType"
-                  defaultValue="SCHEDULE"
-                  value={categoryInput.color}
+                  value={categoryInput.categoryType}
                   onChange={handleChangeInput}
                   className='block p-2.5 mb-2 w-full text-sm text-gray-900 bg-gray-50 rounded-lg border border-gray-300 focus:ring-blue-500 focus:border-blue-500'
                 >


### PR DESCRIPTION
### 변경 내용
AS-IS
카테고리 추가 폼 화면에서 문서/일정 타입 셀렉트박스 선택이 안됨

TO-BE
카테고리 추가 폼 화면에서 문서/일정 타입 셀렉트박스 선택 가능하도록 수정

### 테스트
* [ ] 테스트 코드
* [ ] API 테스트

### 관련 이슈
없음

### 변경 사항 검토
* [ ] api 문서 업데이트

### 특이 사항
없음