### PR TITLE
Feat/front calendar connect

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -38,7 +38,7 @@ export const WrapperDiv = styled.div`
 
   @media (min-width: 1024px) {
     max-width: 1024px;
-    min-height: 1080px;
+    min-height: 800px;
     // width: 1024px;
     height: auto;
   }

--- a/frontend/src/components/Calendar/CalendarCategory.tsx
+++ b/frontend/src/components/Calendar/CalendarCategory.tsx
@@ -136,13 +136,16 @@ const CalendarCategory = ({ categoryList, myTeamMemberId, setCategoryList }: any
             추가
           </button>
         </div>
-        <ul className="h-48 px-3 pb-3  text-sm text-gray-700" aria-labelledby="dropdownSearchButton">
+        <ul className="h-48 px-3 pb-3 text-sm text-gray-700" aria-labelledby="dropdownSearchButton">
           {categoryList.map((opt: any) => (
             <li key={opt.categoryId} className="flex items-center p-2 rounded hover:bg-gray-100">
-              <input type="checkbox" value="" className="w-4 h-4 checkbox checkbox-success text-green-600 bg-gray-100 border-gray-300 rounded focus:ring-green-50" />
-              <label className="w-full ms-2 text-sm font-medium text-gray-900 rounded">{opt.categoryName}</label>
-              <button onClick={toggleDeleteModal} value={opt.categoryId} className="w-4 h-4 text-gray-700 border border-gray-200 hover:bg-red-500 hover:text-white focus:ring-4 focus:outline-none focus:ring-red-500 font-medium rounded-lg text-sm p-2.5 text-center inline-flex items-center me-2">
-                x
+              {/* <input type="checkbox" value="" className="w-4 h-4 checkbox checkbox-success text-green-600 bg-gray-100 border-gray-300 rounded focus:ring-green-50" /> */}
+              <svg className="w-3.5 h-3.5 text-green-500 dark:text-green-400 flex-shrink-0" aria-hidden="true" xmlns="http://www.w3.org/2000/svg" fill="currentColor" viewBox="0 0 20 20">
+                <path d="M10 .5a9.5 9.5 0 1 0 9.5 9.5A9.51 9.51 0 0 0 10 .5Zm3.707 8.207-4 4a1 1 0 0 1-1.414 0l-2-2a1 1 0 0 1 1.414-1.414L9 10.586l3.293-3.293a1 1 0 0 1 1.414 1.414Z"/>
+              </svg>
+              <span className="w-full ms-2 text-sm font-medium text-gray-900 rounded">{opt.categoryName}</span>
+              <button onClick={toggleDeleteModal} value={opt.categoryId} className="w-4 h-4 justify-center text-gray-700 border border-gray-200 hover:bg-red-500 hover:text-white focus:ring-4 focus:outline-none focus:ring-red-500 font-medium rounded-lg text-sm p-2.5 text-center inline-flex items-center me-2">
+                <span className="">x</span>
                 <span className="sr-only">카테고리 삭제 버튼</span>
               </button>
             </li>

--- a/frontend/src/components/Calendar/CalendarCategory.tsx
+++ b/frontend/src/components/Calendar/CalendarCategory.tsx
@@ -90,7 +90,7 @@ const CalendarCategory = ({ categoryList, myTeamMemberId, setCategoryList }: any
         createParticipantId: myTeamMemberId,
         categoryName: categoryInput.categoryName,
         categoryType: "SCHEDULE",
-        color: categoryInput.color,
+        color: "",
       }
       );
       if (res.status === 200) {
@@ -127,6 +127,53 @@ const CalendarCategory = ({ categoryList, myTeamMemberId, setCategoryList }: any
     }
   };
 
+  // 카테고리 수정
+  const [isCategoryEdit, setIsCategoryEdit] = useState(false);
+  const [editedId, setEditedId] = useState(0);
+  // const toggleCatIsEdit = () => setIsCategoryEdit(!isCategoryEdit);
+  
+  const toggleCatIsEdit = (e: any) => {
+    // 수정버튼 클릭된 카테고리 id
+    console.log("수정버튼 클릭된 카테고리아이디-> ",e.target.id)
+    setEditedId(e.target.id);
+    
+    setIsCategoryEdit(!isCategoryEdit);
+    toggleAddModal();
+  };
+
+  const handleCategoryEdit = (e: any) => {
+    if(categoryInput.categoryName.length < 1){
+      categoryNameInput.current?.focus();
+      e.preventDefault();
+      return;
+    }
+    
+    onEditCategory();
+  };
+  
+  const onEditCategory = async () => {
+    // e.preventDefault();
+    try {
+      const res = await axiosInstance.put(`/category`, 
+      {
+        categoryId: editedId,
+        teamId: teamId,
+        updateParticipantId: myTeamMemberId,
+        categoryName: categoryInput.categoryName,
+        categoryType: "SCHEDULE",
+        color: "",
+      }
+      );
+      if (res.status === 200) {
+        console.log("카테고리 옵션이 수정되었습니다 -> ", res);
+        // setCategoryList(res.data.content);
+        return;
+      }
+    } catch (error) {
+      console.log(error);
+    }
+  }
+
   return (
     <>
       <div className="p-3 bg-white rounded-lg shadow w-60">
@@ -148,19 +195,31 @@ const CalendarCategory = ({ categoryList, myTeamMemberId, setCategoryList }: any
                 <span className="">x</span>
                 <span className="sr-only">카테고리 삭제 버튼</span>
               </button>
+              <button onClick={toggleCatIsEdit} className="w-4 h-4 justify-center text-gray-700 border border-gray-200 hover:bg-red-500 hover:text-white focus:ring-4 focus:outline-none focus:ring-red-500 font-medium rounded-lg text-sm p-2.5 text-center inline-flex items-center me-2">
+                <span className="" id={opt.categoryId}>✎</span>
+                <span className="sr-only">카테고리 수정 버튼</span>
+              </button>
             </li>
           ))}
         </ul>
       </div>
-      {/* 카테고리 추가 폼 */}
+      {/* 카테고리 추가, 수정 폼 */}
       {isAddModal && (
         <Modal>
           <Overlay
-            onClick={toggleAddModal}
+            // onClick={toggleAddModal}
           ></Overlay>
           <ModalContent>
             <div className='p-4 md:p-5'>
-              <h2 className="text-lg font-semibold text-gray-900">카테고리 추가</h2>
+              {isCategoryEdit ? (
+                <>
+                  <h2 className="text-lg font-semibold text-gray-900">카테고리 수정</h2>
+                </>
+              ): (
+                <>
+                  <h2 className="text-lg font-semibold text-gray-900">카테고리 추가</h2>
+                </>
+              )}
               <CategoryForm>
                 <label className='block mt-2 mb-2 text-sm font-medium text-gray-900'>타입</label>
                 <select
@@ -181,9 +240,9 @@ const CalendarCategory = ({ categoryList, myTeamMemberId, setCategoryList }: any
                   name="categoryName"
                   value={categoryInput.categoryName}
                   onChange={handleChangeInput}
-                  className='block p-2.5 w-full text-sm text-gray-900 bg-gray-50 rounded-lg border border-gray-300 focus:ring-blue-500 focus:border-blue-500'
+                  className='block p-2.5 mb-4 w-full text-sm text-gray-900 bg-gray-50 rounded-lg border border-gray-300 focus:ring-blue-500 focus:border-blue-500'
                 ></input>
-                <label className='block mt-2 mb-2 text-sm font-medium text-gray-900'>색상</label>
+                {/* <label className='block mt-2 mb-2 text-sm font-medium text-gray-900'>색상</label>
                 <select
                   name="color"
                   value={categoryInput.color}
@@ -193,16 +252,38 @@ const CalendarCategory = ({ categoryList, myTeamMemberId, setCategoryList }: any
                   <option value="#7aac7a">초록</option>
                   <option value="#E21D29">빨강</option>
                   <option value="#336699">파랑</option>
-                </select>
-                <CommonSubmitBtn
-                  onClick={handleCategoryAdd}
-                >등록</CommonSubmitBtn>
+                </select> */}
+                {isCategoryEdit ? (
+                  <>
+                    <CommonSubmitBtn
+                      onClick={handleCategoryEdit}
+                    >수정</CommonSubmitBtn>
+                  </>
+                ): (
+                  <>
+                    <CommonSubmitBtn
+                      onClick={handleCategoryAdd}
+                    >등록</CommonSubmitBtn>
+                  </>
+                )}
               </CategoryForm>
-              <CloseModal
-                onClick={toggleAddModal}
-              >
-                닫기
-              </CloseModal>
+              {isCategoryEdit ? (
+                <>
+                  <CloseModal
+                    onClick={toggleCatIsEdit}
+                  >
+                    닫기
+                  </CloseModal>
+                </>
+              ): (
+                <>
+                  <CloseModal
+                    onClick={toggleAddModal}
+                  >
+                    닫기
+                  </CloseModal>
+                </>
+              )}
             </div>
           </ModalContent>
         </Modal>

--- a/frontend/src/components/Calendar/TeamCalender.tsx
+++ b/frontend/src/components/Calendar/TeamCalender.tsx
@@ -45,6 +45,7 @@ const TeamCalender = ({ categoryList, myTeamMemberId }: any) => {
       content: e.event.extendedProps.content,
       place: e.event.extendedProps.place,
       groupId: e.event.extendedProps.categoryName,
+      categoryId: e.event.extendedProps.categoryId,
     });
     toggleModal();
   }
@@ -74,6 +75,7 @@ const TeamCalender = ({ categoryList, myTeamMemberId }: any) => {
         scheduleType: event.scheduleType,
         category: event.category,
         categoryName: event.categoryName,
+        categoryId: event.categoryId,
       }
     }));
   };

--- a/frontend/src/components/Home/HomeContent.tsx
+++ b/frontend/src/components/Home/HomeContent.tsx
@@ -144,6 +144,7 @@ const TeamListContainer = styled.div`
   justify-content: flex-start;
   gap: 5px;
   padding: 8px;
+  padding-top: 50px;
 
   @media (max-width: 600px) {
     width: 100%;

--- a/frontend/src/components/Join/SignUpStyled.tsx
+++ b/frontend/src/components/Join/SignUpStyled.tsx
@@ -5,6 +5,7 @@ export const StyledContainer = styled.div`
   padding: 20px;
   max-width: 400px;
   margin: auto;
+  padding-top: 170px;
 `;
 
 export const StyledFormItem = styled.div`

--- a/frontend/src/components/MainContents.tsx
+++ b/frontend/src/components/MainContents.tsx
@@ -29,7 +29,7 @@ export default MainContents;
 
 // 스타일드 컴포넌트
 export const MainContentsSpan = styled.span`
-  margin-top: 200px;
+  padding-top: 200px;
   display: flex;
   align-items: center;
   justify-content: space-between;

--- a/frontend/src/components/MyInfoPage/MyUserProfileStyled.tsx
+++ b/frontend/src/components/MyInfoPage/MyUserProfileStyled.tsx
@@ -4,6 +4,7 @@ export const UserProfileContainer = styled.div`
   border-radius: 8px;
   margin: auto;
   width: 600px;
+  padding-top: 50px;
 `;
 
 export const UserProfileTitle = styled.h2`

--- a/frontend/src/components/ProfilePage/TeamLeaderStyled.tsx
+++ b/frontend/src/components/ProfilePage/TeamLeaderStyled.tsx
@@ -7,6 +7,7 @@ export const TeamLeaderContainer = styled.div`
   justify-content: flex-start;
   height: 100vh;
   margin-top: 10px;
+  padding-top: 80px;
 `;
 
 export const CenteredContainer = styled.div`
@@ -110,6 +111,8 @@ export const MoveTeamPage = styled.div`
   text-align: right;
   margin-right: 100px;
   cursor: pointer;
+  padding-top: 100px;
+
   &:hover {
     color: #a3cca3;
   }

--- a/frontend/src/components/documentEditor/DocumentList.tsx
+++ b/frontend/src/components/documentEditor/DocumentList.tsx
@@ -244,6 +244,8 @@ const DocumentContainer = styled.div`
   align-content: space-between;
   flex-wrap: wrap;
   margin-bottom: 20px;
+  padding-top: 30px;
+
 `;
 
 const DocumentItem = styled.div`
@@ -294,6 +296,8 @@ const Container = styled.section`
   margin: 0 auto;
   display: flex;
   flex-direction: column;
+  padding-top: 50px;
+
 `;
 
 const InputAndButton = styled.div`

--- a/frontend/src/interface/interface.ts
+++ b/frontend/src/interface/interface.ts
@@ -77,5 +77,6 @@ export interface ConvertedEvent {
     scheduleType: string;
     category: string;
     categoryName: string;
+    categoryId: number,
   };
 }

--- a/frontend/src/views/Calender.tsx
+++ b/frontend/src/views/Calender.tsx
@@ -2,7 +2,7 @@ import CalendarView from "../components/Calendar/CalendarView";
 
 const Calender = () => {
   return (
-    <div className="flex min-h-screen flex-col items-center justify-between">
+    <div className="flex min-h-screen flex-col items-center justify-between pt-10">
       <div className="grid grid-cols-10">
         <CalendarView />
       </div>

--- a/frontend/src/views/HomeView.tsx
+++ b/frontend/src/views/HomeView.tsx
@@ -36,4 +36,5 @@ export default homeView;
 const HomeViewContainer = styled.div`
   max-width: 800px;
   margin: 0 auto;
+  padding-top: 50px;
 `;

--- a/frontend/src/views/SignInView.tsx
+++ b/frontend/src/views/SignInView.tsx
@@ -22,4 +22,5 @@ const StyledSignInView = styled.section`
   flex-direction: column;
   align-items: center;
   justify-content: center;
+  padding-top: 200px;
 `;


### PR DESCRIPTION
### 변경 내용
AS-IS
카테고리 목록 리스트에, 카테고리 이름 앞에 체크박스 요소 갖고있음
컨텐츠 영역 요소들이 상단에 가까이 붙어있음
일정 수정할때 기존에 지정되어있는 카테고리와 다른 것으로 선택해야 수정이 가능한 이슈 존재

TO-BE
카테고리 목록의 체크박스 제거, 카테고리 목록 스타일로 아이콘으로 변경
컨텐츠 영역 요소들 상단에 padding 스타일을 추가하여 간격을 둠
일정 수정할때 카테고리를 변경하지 않아도 수정이 가능하도록 함
카테고리 수정 버튼 및 기능 추가

### 테스트
* [ ] 테스트 코드
* [ ] API 테스트

### 관련 이슈
없음

### 변경 사항 검토
* [ ] api 문서 업데이트

### 특이 사항
없음

### 스크린샷 (선택 사항)
![image](https://github.com/100backfro/teammate/assets/110381560/9863d793-49a0-482c-9841-d65ff715ced7)
![image](https://github.com/100backfro/teammate/assets/110381560/03e43e22-9573-4b6d-af34-e2858eb61535)