### PR TITLE
Feat/front calendar connect

### DIFF
--- a/frontend/src/components/Calendar/EditEvent.tsx
+++ b/frontend/src/components/Calendar/EditEvent.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from "react";
+import { useState, useEffect, useRef } from "react";
 import { useParams } from "react-router-dom";
 import axiosInstance from "../../axios.tsx";
 import styled from "styled-components";
@@ -106,8 +106,21 @@ const EditEvent = ({
     setParticipantsIds(valuesArray);
   };
 
-  // 새 일정 등록 요청
-  const handleScheduleSubmit = async () => {
+  // 필수 입력값
+  const eventTitleInput = useRef<HTMLInputElement | null>(null);
+
+  // 새 일정 등록
+  const handleScheduleAdd = (e: any) => {
+    if(eventChange.title.length < 1){
+      eventTitleInput.current?.focus();
+      e.preventDefault();
+      return;
+    }
+
+    onAddSchedule();
+  }
+
+  const onAddSchedule = async () => {
     // e.preventDefault();
     let result = eventChange;
     result.teamParticipantsIds = participantsIds;
@@ -139,7 +152,17 @@ const EditEvent = ({
   };
 
   // 일정 수정 
-  const handleScheduleModify = async () => {
+  const handleScheduleModify = (e: any) => {
+    if(eventChange.title.length < 1){
+      eventTitleInput.current?.focus();
+      e.preventDefault();
+      return;
+    }
+
+    onModifySchedule();
+  }
+
+  const onModifySchedule = async () => {
     // e.preventDefault();
 
     let result = eventChange;
@@ -217,6 +240,7 @@ const EditEvent = ({
           일정제목
         </label>
         <EventInput
+          ref={eventTitleInput}
           type="text"
           name="title"
           id="title"
@@ -310,7 +334,7 @@ const EditEvent = ({
           onChange={handleEventChange}
           className="bg-gray-50 border border-gray-300 text-gray-900 text-sm rounded-lg focus:ring-primary-500 focus:border-primary-500 block w-full p-2.5"
         >
-          <option value="#7aac7a">초록</option>
+          <option value="#7AAC7A">초록</option>
           <option value="#E21D29">빨강</option>
           <option value="#336699">파랑</option>
         </select>
@@ -343,7 +367,7 @@ const EditEvent = ({
         </>
       ) : (
         <CommonSubmitBtn
-          onClick={handleScheduleSubmit}
+          onClick={handleScheduleAdd}
           className="mt-2"
         >
           등록

--- a/frontend/src/components/Calendar/TeamCalender.tsx
+++ b/frontend/src/components/Calendar/TeamCalender.tsx
@@ -189,7 +189,7 @@ const TeamCalender = ({ categoryList, myTeamMemberId }: any) => {
                   {/* 일정 번호: {event.id} */}
                   {/* 이름: {event.title}<br /> */}
                   <div className="mb-3">
-                    <span className="mr-10 text-gray-500">일시</span><span className="">{event.start.toJSON()}</span>
+                    <span className="mr-10 text-gray-500">일시</span><span className="">{event.start.toISOString().split(':00')[0].replace("T", " ")}</span>
                   </div>
                   <div className="mb-3">
                     <span className="mr-10 text-gray-500">내용</span>{event.content}


### PR DESCRIPTION
### 변경 내용
AS-IS
캘린더 일정 상세보기할때 일시가 YYYY-MM-DDTHH:MM:(...)으로 표시됨
캘린더 일정 추가/수정할 때 초록색을 선택했어도 빨간색으로 표시되는 이슈 존재
캘린더 일정 추가/수정할 때 제목 입력란이 비어있으면 등록되지않고 리렌더링 되어짐

TO-BE
캘린더 일정 상세보기할때 일시가 YYYY-MM-DD HH:MM 으로 표시되도록 수정
캘린더 일정 추가/수정할 때 초록색을 선택하면 초록색으로 표시되도록 수정
캘린더 일정 추가/수정할 때 제목 입력란이 비어있으면 등록되지않고 해당 입력란에 포커싱

### 테스트
* [ ] 테스트 코드
* [ ] API 테스트

### 관련 이슈
없음

### 변경 사항 검토
* [ ] api 문서 업데이트

### 특이 사항
없음