### PR TITLE
Add: 일정, 카테고리 생성자가 존재하는데 팀장권한으로 삭제시 불가능 안내 알림창 추가

### DIFF
--- a/frontend/src/components/Calendar/CalendarCategory.tsx
+++ b/frontend/src/components/Calendar/CalendarCategory.tsx
@@ -104,8 +104,8 @@ const CalendarCategory = ({ categoryList, myTeamMemberId, setCategoryList }: any
   }
 
   // 카테고리 삭제 동작
-  const handleCategoryDelete = async () => {
-    // e.preventDefault();
+  const handleCategoryDelete = async (e: any) => {
+    e.preventDefault();
     try {
       const res = await axiosInstance.delete(`/category`, {
         data: {
@@ -124,6 +124,7 @@ const CalendarCategory = ({ categoryList, myTeamMemberId, setCategoryList }: any
       }
     } catch (error) {
       console.log(error);
+      alert("카테고리 생성자가 팀 내에 존재하므로, 팀장권한으로 삭제가 불가능합니다.");
     }
   };
 

--- a/frontend/src/components/Calendar/TeamCalender.tsx
+++ b/frontend/src/components/Calendar/TeamCalender.tsx
@@ -129,6 +129,7 @@ const TeamCalender = ({ categoryList, myTeamMemberId }: any) => {
       }
     } catch (error) {
       console.log(error);
+      alert("일정 생성자가 팀 내에 존재하므로, 팀장권한으로 삭제가 불가능합니다.");
     }
   }
 


### PR DESCRIPTION
### 변경 내용
AS-IS

TO-BE
일정, 카테고리 생성한 팀원이 팀 내에 존재하는데 팀장이 삭제 시도시 삭제 불가능 알림창 띄움

### 테스트
* [ ] 테스트 코드
* [ ] API 테스트

### 관련 이슈
없음

### 변경 사항 검토
* [ ] api 문서 업데이트

### 특이 사항
없음

### 스크린샷 (선택 사항)
![image](https://github.com/100backfro/teammate/assets/110381560/ce416bee-e9fa-482f-93d0-4c663032c698)