### PR TITLE
Fix: 캘린더 일정 기본 색 초록색으로 수정

### DIFF
--- a/frontend/src/components/Calendar/EditEvent.tsx
+++ b/frontend/src/components/Calendar/EditEvent.tsx
@@ -79,7 +79,7 @@ const EditEvent = ({
     startDt: originEvent.start,
     endDt: originEvent.end,
     repeatCycle: null,
-    color: "#ff0000",
+    color: "#7AAC7A",
     createParticipantId: myTeamMemberId,
     teamParticipantsIds: [] as any,
   });


### PR DESCRIPTION
### 변경 내용
AS-IS

TO-BE
캘린더 일정 작성할때 기본색을 초록색으로 해두어 초록색을 지정했는데도 빨간색으로 되지 않도록 수정

### 테스트 
* [ ] 테스트 코드
* [ ] API 테스트

### 관련 이슈
없음

### 변경 사항 검토
* [ ] api 문서 업데이트

### 특이 사항
없음